### PR TITLE
Add admin preference to allow basic auth (passwords) to be transmitted over http connections.

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/sync/service/SyncExecutionContext.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/SyncExecutionContext.java
@@ -80,6 +80,7 @@ public class SyncExecutionContext implements SynchronizerStatus {
   private final String username;
   private final String password;
   private final String installationId;
+  private final Boolean allowUnsafeAuthentication;
 
   private final String deviceId;
 
@@ -111,6 +112,8 @@ public class SyncExecutionContext implements SynchronizerStatus {
     this.password = props.getProperty(CommonToolProperties.KEY_PASSWORD);
 
     this.installationId = props.getProperty(CommonToolProperties.KEY_INSTALLATION_ID);
+    this.allowUnsafeAuthentication = props.getBooleanProperty(CommonToolProperties
+        .KEY_ALLOW_NON_SECURE_AUTHENTICATION);
 
     PropertyManager propertyManager = new PropertyManager(context);
     this.deviceId = propertyManager.getSingularProperty(PropertyManager.OR_DEVICE_ID_PROPERTY,
@@ -239,6 +242,14 @@ public class SyncExecutionContext implements SynchronizerStatus {
 
   public String getInstallationId() {
     return installationId;
+  }
+
+  public boolean getAllowUnsafeAuthentication() {
+    if ( allowUnsafeAuthentication == null ) {
+      return false;
+    } else {
+      return allowUnsafeAuthentication;
+    }
   }
 
   public HashMap<String,Object> getDeviceInfo() {

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/HttpRestProtocolWrapper.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/HttpRestProtocolWrapper.java
@@ -278,6 +278,7 @@ public class HttpRestProtocolWrapper {
         asList.add(a);
         // this might be disabled in production builds...
         if ( sc.getAllowUnsafeAuthentication() ) {
+          log.e(LOGTAG, "Enabling Unsafe Authentication!");
           a = new AuthScope(host, -1, null, AuthSchemes.BASIC);
           asList.add(a);
         }

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/HttpRestProtocolWrapper.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/HttpRestProtocolWrapper.java
@@ -269,14 +269,18 @@ public class HttpRestProtocolWrapper {
       {
         AuthScope a;
         // allow digest auth on any port...
-        // TODO switch this to digest
-        a = new AuthScope(host, -1, null, AuthSchemes.BASIC);
+        a = new AuthScope(host, -1, null, AuthSchemes.DIGEST);
         asList.add(a);
         // and allow basic auth on the standard TLS/SSL ports...
         a = new AuthScope(host, 443, null, AuthSchemes.BASIC);
         asList.add(a);
         a = new AuthScope(host, 8443, null, AuthSchemes.BASIC);
         asList.add(a);
+        // this might be disabled in production builds...
+        if ( sc.getAllowUnsafeAuthentication() ) {
+          a = new AuthScope(host, -1, null, AuthSchemes.BASIC);
+          asList.add(a);
+        }
       }
 
       // add username

--- a/services_app/src/main/res/values/strings.xml
+++ b/services_app/src/main/res/values/strings.xml
@@ -293,7 +293,8 @@
 
     <string name="restrict_server_settings_summary">Limit non-Admin ability to change Server Settings</string>
     <string name="restrict_server">Manage ability to change Server Settings</string>
-
+    <string name="non_secure_authentication">Allow unsafe/unsecure Authentication</string>
+    <string name="non_secure_summary">Authenticate over http: (testing support)</string>
     <string name="credential">Server Sign-on Credential</string>
     <string name="change_credential">Change Sign-on Credential</string>
 

--- a/services_app/src/main/res/values/strings.xml
+++ b/services_app/src/main/res/values/strings.xml
@@ -293,8 +293,6 @@
 
     <string name="restrict_server_settings_summary">Limit non-Admin ability to change Server Settings</string>
     <string name="restrict_server">Manage ability to change Server Settings</string>
-    <string name="non_secure_authentication">Allow unsafe/unsecure Authentication</string>
-    <string name="non_secure_summary">Authenticate over http: (testing support)</string>
     <string name="credential">Server Sign-on Credential</string>
     <string name="change_credential">Change Sign-on Credential</string>
 
@@ -308,6 +306,10 @@
     <string name="no_account">No account</string>
     <string name="anonymous">None (anonymous access)</string>
     <string name="credential_type_prefix">Credentials: </string>
+
+    <string name="testing_support">Non-Production (Test) Settings:</string>
+    <string name="non_secure_authentication">Allow unsafe/unsecure Authentication</string>
+    <string name="non_secure_summary">Authenticate over http: (testing support)</string>
 
     <string name="restrict_device_settings_summary">Limit non-Admin ability to change Device Settings</string>
     <string name="restrict_device">Manage ability to change Device Settings</string>

--- a/services_app/src/main/res/xml/admin_configurable_server_preferences.xml
+++ b/services_app/src/main/res/xml/admin_configurable_server_preferences.xml
@@ -1,4 +1,4 @@
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+<PreferenceScreen xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <PreferenceCategory android:title="@string/user_access_preferences" >
         <CheckBoxPreference
@@ -25,6 +25,8 @@
             android:key="common.change_google_account"
             android:title="@string/selected_google_account_text" 
             android:persistent="false" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/testing_support">
         <CheckBoxPreference
                 android:id="@+id/allow_non_secure_authentications"
                 android:defaultValue="false"

--- a/services_app/src/main/res/xml/admin_configurable_server_preferences.xml
+++ b/services_app/src/main/res/xml/admin_configurable_server_preferences.xml
@@ -25,6 +25,13 @@
             android:key="common.change_google_account"
             android:title="@string/selected_google_account_text" 
             android:persistent="false" />
+        <CheckBoxPreference
+                android:id="@+id/allow_non_secure_authentications"
+                android:defaultValue="false"
+                android:key="common.non_secure_authentication"
+                android:title="@string/non_secure_authentication"
+                android:summary="@string/non_secure_summary"
+                android:persistent="false"/>
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
This creates an admin setting that would allow test servers to not have ssl certs.
This also fixes the issue preventing ODK Aggregate v1.4.14 servers from working automatically with ODK Services (that can also be remedied by changing the security.properties file to specify basic instead of digest auth).
