### PR TITLE
Fix crash on checkpoint resolution when mAppName is null

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/resolve/checkpoint/CheckpointResolutionListFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/resolve/checkpoint/CheckpointResolutionListFragment.java
@@ -222,8 +222,7 @@ public class CheckpointResolutionListFragment extends ListFragment implements Lo
   private void resolveConflictList(boolean takeNewest) {
     if (mAdapter.getCount() > 0) {
       if (checkpointResolutionListTask == null) {
-        checkpointResolutionListTask = new CheckpointResolutionListTask(getActivity(), takeNewest);
-        checkpointResolutionListTask.setAppName(mAppName);
+        checkpointResolutionListTask = new CheckpointResolutionListTask(getActivity(), takeNewest, mAppName);
         checkpointResolutionListTask.setTableId(mTableId);
         checkpointResolutionListTask.setResolveRowEntryAdapter(mAdapter);
         checkpointResolutionListTask.setResolutionListener(this);

--- a/services_app/src/main/java/org/opendatakit/services/resolve/task/CheckpointResolutionListTask.java
+++ b/services_app/src/main/java/org/opendatakit/services/resolve/task/CheckpointResolutionListTask.java
@@ -32,7 +32,10 @@ public class CheckpointResolutionListTask extends AsyncTask<Void, String, String
   String mProgress = "";
   String mResult = null;
 
-  public CheckpointResolutionListTask(Context context, boolean takeNewest) {
+  public CheckpointResolutionListTask(Context context, boolean takeNewest, String appName) {
+    // There are times when this constructor is called and mAppName has no value
+    // and getActiveUserAndLocale crashes so we need the appName in the constructor
+    mAppName = appName;
     aul = ActiveUserAndLocale.getActiveUserAndLocale(context, mAppName);
 
     formatStrResolvingRowNofM = context.getString(R.string.resolving_row_n_of_m);


### PR DESCRIPTION
When trying to resolve conflicts, sometimes mAppName within CheckpointResolutionListTask is null in the constructor.  A crash is caused when the ActiveUserAndLocale.getActiveUserAndLocale(context, mAppName); tries to use the null value.