### PR TITLE
Validate table health before changing authentication

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/preferences/activities/AppPropertiesActivity.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/activities/AppPropertiesActivity.java
@@ -287,4 +287,8 @@ public class AppPropertiesActivity extends PreferenceActivity implements IOdkApp
     AlertDialog dialog = builder.create();
     dialog.show();
   }
+
+  public String getAppName() {
+    return mAppName;
+  }
 }

--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
@@ -16,6 +16,7 @@ package org.opendatakit.services.preferences.fragments;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Fragment;
 import android.app.FragmentTransaction;
@@ -42,6 +43,8 @@ import org.opendatakit.properties.CommonToolProperties;
 import org.opendatakit.properties.PropertiesSingleton;
 import org.opendatakit.services.preferences.PasswordPreferenceScreen;
 import org.opendatakit.services.R;
+import org.opendatakit.services.sync.actions.LoginActions;
+import org.opendatakit.services.sync.actions.activities.LoginActivity;
 import org.opendatakit.services.sync.actions.activities.SyncActivity;
 import org.opendatakit.services.utilities.TableHealthValidator;
 
@@ -368,6 +371,13 @@ public class ServerSettingsFragment extends PreferenceFragment implements OnPref
     return true;
   }
 
+  public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
 
+    if (requestCode == RequestCodeConsts.RequestCodes.LAUNCH_CHECKPOINT_RESOLVER ||
+        requestCode == RequestCodeConsts.RequestCodes.LAUNCH_CONFLICT_RESOLVER) {
+      healthValidator.verifyTableHealth();
+    }
+  }
 
 }

--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
@@ -364,6 +364,14 @@ public class ServerSettingsFragment extends PreferenceFragment implements OnPref
   }
 
 
+    /**
+     * The functions below verify that the database is clean, with no new changes, conflicts, or
+     * checkpoint rows, before proceeding to let the user change server settings or authenticate
+     * as a new user.
+     *
+     * This logic is very similar in LoginFragment.java, so any changes here should be considered in
+     * that file as well.
+     */
     private void verifyTableHealth() {
         String appName = ((AppPropertiesActivity) getActivity()).getAppName();
         WebLogger.getLogger(appName).i(t, "[" + getId() + "] [verifyTableHealth]");

--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
@@ -43,6 +43,7 @@ import org.opendatakit.properties.PropertiesSingleton;
 import org.opendatakit.services.preferences.PasswordPreferenceScreen;
 import org.opendatakit.services.R;
 import org.opendatakit.services.sync.actions.activities.SyncActivity;
+import org.opendatakit.services.utilities.TableHealthValidator;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -62,12 +63,16 @@ public class ServerSettingsFragment extends PreferenceFragment implements OnPref
   private ListPreference mSignOnCredentialPreference;
   private EditTextPreference mUsernamePreference;
   private ListPreference mSelectedGoogleAccountPreference;
+  private TableHealthValidator healthValidator;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
     PropertiesSingleton props = ((IOdkAppPropertiesActivity) this.getActivity()).getProps();
+
+    String appName = ((AppPropertiesActivity) getActivity()).getAppName();
+    healthValidator = new TableHealthValidator(appName, getActivity());
 
     addPreferencesFromResource(R.xml.server_preferences);
 
@@ -300,7 +305,7 @@ public class ServerSettingsFragment extends PreferenceFragment implements OnPref
       serverCategory.setTitle(R.string.server_restrictions_apply);
     }
 
-    verifyTableHealth();
+    healthValidator.verifyTableHealth();
   }
 
   /**
@@ -364,155 +369,5 @@ public class ServerSettingsFragment extends PreferenceFragment implements OnPref
   }
 
 
-    /**
-     * The functions below verify that the database is clean, with no new changes, conflicts, or
-     * checkpoint rows, before proceeding to let the user change server settings or authenticate
-     * as a new user.
-     *
-     * This logic is very similar in LoginFragment.java, so any changes here should be considered in
-     * that file as well.
-     */
-    private void verifyTableHealth() {
-        String appName = ((AppPropertiesActivity) getActivity()).getAppName();
-        WebLogger.getLogger(appName).i(t, "[" + getId() + "] [verifyTableHealth]");
 
-        OdkConnectionInterface db = null;
-        DbHandle dbHandleName = new DbHandle(UUID.randomUUID().toString());
-
-        List<String> checkpointTables = new LinkedList<>();
-        List<String> conflictTables = new LinkedList<>();
-        boolean hasChanges = false;
-
-        try {
-            // +1 referenceCount if db is returned (non-null)
-            db = OdkConnectionFactorySingleton.getOdkConnectionFactoryInterface()
-                    .getConnection(appName, dbHandleName);
-            List<String> tableIds = ODKDatabaseImplUtils.get().getAllTableIds(db);
-
-            for (String tableId : tableIds) {
-                int health = ODKDatabaseImplUtils.get().getTableHealth(db, tableId);
-
-                if (CursorUtils.getTableHealthIsClean(health)) {
-                    continue;
-                }
-
-                if (!hasChanges && CursorUtils.getTableHealthHasChanges(health)) {
-                    hasChanges = true;
-                }
-
-                if (CursorUtils.getTableHealthHasConflicts(health)) {
-                    conflictTables.add(tableId);
-                }
-
-                if (CursorUtils.getTableHealthHasCheckpoints(health)) {
-                    checkpointTables.add(tableId);
-                }
-            }
-        } finally {
-            if (db != null) {
-                // release the reference...
-                // this does not necessarily close the db handle
-                // or terminate any pending transaction
-                db.releaseReference();
-            }
-        }
-
-        WebLogger.getLogger(appName).i(t,
-                "[" + getId() + "] [verifyTableHealth] " + "summary:\n\tUnsynced changes present: "
-                        + hasChanges + "\n\tNumber of conflict rows present: " + conflictTables.size()
-                        + "\n\tNumber of checkpoint rows present: " + checkpointTables.size());
-
-
-        if (hasChanges) {
-            promptToResolveChanges(checkpointTables, conflictTables);
-        } else {
-            checkForCheckpointAndConflictTables(checkpointTables, conflictTables);
-        }
-    }
-
-    private void promptToResolveChanges(final List<String> checkpointTables,
-                                        final List<String> conflictTables) {
-        final String appName = ((AppPropertiesActivity) getActivity()).getAppName();
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setTitle(R.string.sync_pending_changes);
-        builder.setMessage(R.string.resolve_pending_changes);
-        builder.setPositiveButton(R.string.ignore_changes, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                dialog.dismiss();
-                checkForCheckpointAndConflictTables(checkpointTables, conflictTables);
-            }
-        });
-        builder.setNegativeButton(R.string.resolve_with_sync, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                dialog.dismiss();
-
-                // Launch the Sync activity to sync your changes.
-                // TODO: Can we check if we just came from sync and if so just return to that?
-                Intent i = new Intent(getActivity(), SyncActivity.class);
-                i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
-                startActivity(i);
-            }
-        });
-        AlertDialog dialog = builder.create();
-        dialog.show();
-    }
-
-    private void checkForCheckpointAndConflictTables(List<String> checkpointTables,
-                                                     List<String> conflictTables) {
-
-        if ((checkpointTables != null && !checkpointTables.isEmpty()) ||
-                (conflictTables != null && !conflictTables.isEmpty())) {
-            promptToResolveCheckpointsAndConflicts(checkpointTables, conflictTables);
-        }
-
-    }
-
-    private void promptToResolveCheckpointsAndConflicts(final List<String> checkpointTables,
-                                                        final List<String> conflictTables) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setTitle(R.string.resolve_checkpoints_and_conflicts);
-        builder.setMessage(R.string.resolve_pending_checkpoints_and_conflicts);
-        builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                dialog.dismiss();
-                resolveConflictsAndCheckpoints(checkpointTables, conflictTables);
-            }
-        });
-        AlertDialog dialog = builder.create();
-        dialog.show();
-    }
-
-    private void resolveConflictsAndCheckpoints(List<String> checkpointTables, List<String> conflictTables) {
-        String appName = ((AppPropertiesActivity) getActivity()).getAppName();
-
-        if (checkpointTables != null && !checkpointTables.isEmpty()) {
-            Iterator<String> iterator = checkpointTables.iterator();
-            String tableId = iterator.next();
-            checkpointTables.remove(tableId);
-
-            Intent i;
-            i = new Intent();
-            i.setComponent(new ComponentName(IntentConsts.ResolveCheckpoint.APPLICATION_NAME,
-                    IntentConsts.ResolveCheckpoint.ACTIVITY_NAME));
-            i.setAction(Intent.ACTION_EDIT);
-            i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
-            i.putExtra(IntentConsts.INTENT_KEY_TABLE_ID, tableId);
-            this.startActivityForResult(i, RequestCodeConsts.RequestCodes.LAUNCH_CHECKPOINT_RESOLVER);
-        }
-        if (conflictTables != null && !conflictTables.isEmpty()) {
-            Iterator<String> iterator = conflictTables.iterator();
-            String tableId = iterator.next();
-            conflictTables.remove(tableId);
-
-            Intent i;
-            i = new Intent();
-            i.setComponent(new ComponentName(IntentConsts.ResolveConflict.APPLICATION_NAME,
-                    IntentConsts.ResolveConflict.ACTIVITY_NAME));
-            i.setAction(Intent.ACTION_EDIT);
-            i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
-            i.putExtra(IntentConsts.INTENT_KEY_TABLE_ID, tableId);
-            this.startActivityForResult(i, RequestCodeConsts.RequestCodes.LAUNCH_CONFLICT_RESOLVER);
-        }
-    }
 }

--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
@@ -19,6 +19,7 @@ import android.accounts.AccountManager;
 import android.app.AlertDialog;
 import android.app.Fragment;
 import android.app.FragmentTransaction;
+import android.content.ComponentName;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -28,6 +29,7 @@ import android.text.InputFilter;
 import android.text.Spanned;
 import android.widget.Toast;
 import org.opendatakit.consts.IntentConsts;
+import org.opendatakit.consts.RequestCodeConsts;
 import org.opendatakit.database.service.DbHandle;
 import org.opendatakit.database.utilities.CursorUtils;
 import org.opendatakit.logging.WebLogger;
@@ -46,6 +48,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -360,9 +363,9 @@ public class ServerSettingsFragment extends PreferenceFragment implements OnPref
     return true;
   }
 
+
     private void verifyTableHealth() {
         String appName = ((AppPropertiesActivity) getActivity()).getAppName();
-
         WebLogger.getLogger(appName).i(t, "[" + getId() + "] [verifyTableHealth]");
 
         OdkConnectionInterface db = null;
@@ -411,22 +414,25 @@ public class ServerSettingsFragment extends PreferenceFragment implements OnPref
                         + hasChanges + "\n\tNumber of conflict rows present: " + conflictTables.size()
                         + "\n\tNumber of checkpoint rows present: " + checkpointTables.size());
 
-        // TODO: Add UI to tell user we're about to resolve checkpoints and conflicts
-        // TODO: Deal with conflicts and checkpoints (desktop file)
 
         if (hasChanges) {
-            promptToResolveChanges(appName);
+            promptToResolveChanges(checkpointTables, conflictTables);
+        } else {
+            checkForCheckpointAndConflictTables(checkpointTables, conflictTables);
         }
     }
 
-    private void promptToResolveChanges(final String appName) {
+    private void promptToResolveChanges(final List<String> checkpointTables,
+                                        final List<String> conflictTables) {
+        final String appName = ((AppPropertiesActivity) getActivity()).getAppName();
+
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(R.string.sync_pending_changes);
         builder.setMessage(R.string.resolve_pending_changes);
         builder.setPositiveButton(R.string.ignore_changes, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
                 dialog.dismiss();
-                // Do nothing and continue to login screen
+                checkForCheckpointAndConflictTables(checkpointTables, conflictTables);
             }
         });
         builder.setNegativeButton(R.string.resolve_with_sync, new DialogInterface.OnClickListener() {
@@ -442,5 +448,63 @@ public class ServerSettingsFragment extends PreferenceFragment implements OnPref
         });
         AlertDialog dialog = builder.create();
         dialog.show();
+    }
+
+    private void checkForCheckpointAndConflictTables(List<String> checkpointTables,
+                                                     List<String> conflictTables) {
+
+        if ((checkpointTables != null && !checkpointTables.isEmpty()) ||
+                (conflictTables != null && !conflictTables.isEmpty())) {
+            promptToResolveCheckpointsAndConflicts(checkpointTables, conflictTables);
+        }
+
+    }
+
+    private void promptToResolveCheckpointsAndConflicts(final List<String> checkpointTables,
+                                                        final List<String> conflictTables) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.resolve_checkpoints_and_conflicts);
+        builder.setMessage(R.string.resolve_pending_checkpoints_and_conflicts);
+        builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int id) {
+                dialog.dismiss();
+                resolveConflictsAndCheckpoints(checkpointTables, conflictTables);
+            }
+        });
+        AlertDialog dialog = builder.create();
+        dialog.show();
+    }
+
+    private void resolveConflictsAndCheckpoints(List<String> checkpointTables, List<String> conflictTables) {
+        String appName = ((AppPropertiesActivity) getActivity()).getAppName();
+
+        if (checkpointTables != null && !checkpointTables.isEmpty()) {
+            Iterator<String> iterator = checkpointTables.iterator();
+            String tableId = iterator.next();
+            checkpointTables.remove(tableId);
+
+            Intent i;
+            i = new Intent();
+            i.setComponent(new ComponentName(IntentConsts.ResolveCheckpoint.APPLICATION_NAME,
+                    IntentConsts.ResolveCheckpoint.ACTIVITY_NAME));
+            i.setAction(Intent.ACTION_EDIT);
+            i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
+            i.putExtra(IntentConsts.INTENT_KEY_TABLE_ID, tableId);
+            this.startActivityForResult(i, RequestCodeConsts.RequestCodes.LAUNCH_CHECKPOINT_RESOLVER);
+        }
+        if (conflictTables != null && !conflictTables.isEmpty()) {
+            Iterator<String> iterator = conflictTables.iterator();
+            String tableId = iterator.next();
+            conflictTables.remove(tableId);
+
+            Intent i;
+            i = new Intent();
+            i.setComponent(new ComponentName(IntentConsts.ResolveConflict.APPLICATION_NAME,
+                    IntentConsts.ResolveConflict.ACTIVITY_NAME));
+            i.setAction(Intent.ACTION_EDIT);
+            i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
+            i.putExtra(IntentConsts.INTENT_KEY_TABLE_ID, tableId);
+            this.startActivityForResult(i, RequestCodeConsts.RequestCodes.LAUNCH_CONFLICT_RESOLVER);
+        }
     }
 }

--- a/services_app/src/main/java/org/opendatakit/services/sync/actions/fragments/LoginFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/actions/fragments/LoginFragment.java
@@ -913,6 +913,13 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
       return mAppName;
    }
 
+    /**
+     * The functions below verify that the database is clean, with no new changes, conflicts, or
+     * checkpoint rows, before proceeding to let the user authenticate as a new user.
+     *
+     * This logic is very similar in ServerSettingsFragment.java, so any changes here should be
+     * considered in that file as well.
+     */
    private void verifyTableHealth() {
       WebLogger.getLogger(getAppName()).i(TAG, "[" + getId() + "] [verifyTableHealth]");
 

--- a/services_app/src/main/java/org/opendatakit/services/sync/actions/fragments/LoginFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/actions/fragments/LoginFragment.java
@@ -127,8 +127,7 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
          return;
       }
 
-      if (savedInstanceState != null && savedInstanceState
-          .containsKey(LOGIN_ACTION)) {
+      if (savedInstanceState != null && savedInstanceState.containsKey(LOGIN_ACTION)) {
          String action = savedInstanceState.getString(LOGIN_ACTION);
          try {
             loginAction = LoginActions.valueOf(action);
@@ -171,7 +170,7 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
       togglePasswordText.setOnClickListener(new View.OnClickListener() {
          @Override
          public void onClick(View v) {
-            if(togglePasswordText.isChecked()) {
+            if (togglePasswordText.isChecked()) {
                passwordEditText.setTransformationMethod(null);
             } else {
                passwordEditText.setTransformationMethod(new PasswordTransformationMethod());
@@ -181,7 +180,8 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
 
       authenticateNewUser = (Button) view.findViewById(R.id.change_user_button);
       authenticateNewUser.setOnClickListener(new View.OnClickListener() {
-         @Override public void onClick(View v) {
+         @Override
+         public void onClick(View v) {
             setNewCredentials();
             refreshCredentialsDisplay();
             verifyServerSettings(v);
@@ -190,7 +190,8 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
 
       logout = (Button) view.findViewById(R.id.logout_button);
       logout.setOnClickListener(new View.OnClickListener() {
-         @Override public void onClick(View v) {
+         @Override
+         public void onClick(View v) {
             logout();
          }
       });
@@ -246,28 +247,28 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
       String[] credentialValues = getResources().getStringArray(R.array.credential_entry_values);
       String[] credentialEntries = getResources().getStringArray(R.array.credential_entries);
 
-      if ( credentialToUse == null ) {
+      if (credentialToUse == null) {
          credentialToUse = getString(R.string.credential_type_none);
       }
 
-      for ( int i = 0 ; i < credentialValues.length ; ++i ) {
-         if ( credentialToUse.equals(credentialValues[i]) ) {
+      for (int i = 0; i < credentialValues.length; ++i) {
+         if (credentialToUse.equals(credentialValues[i])) {
             if (!credentialToUse.equals(getString(R.string.credential_type_none))) {
                accountAuthType.setText(credentialEntries[i]);
             }
          }
       }
 
-      if ( credentialToUse.equals(getString(R.string.credential_type_none))) {
+      if (credentialToUse.equals(getString(R.string.credential_type_none))) {
          accountIdentity.setText(getResources().getString(R.string.anonymous));
-      } else if ( credentialToUse.equals(getString(R.string.credential_type_username_password))) {
+      } else if (credentialToUse.equals(getString(R.string.credential_type_username_password))) {
          String username = props.getProperty(CommonToolProperties.KEY_USERNAME);
          if (username == null || username.equals("")) {
             accountIdentity.setText(getResources().getString(R.string.no_account));
          } else {
             accountIdentity.setText(username);
          }
-      } else if ( credentialToUse.equals(getString(R.string.credential_type_google_account))) {
+      } else if (credentialToUse.equals(getString(R.string.credential_type_google_account))) {
          String googleAccount = props.getProperty(CommonToolProperties.KEY_ACCOUNT);
          if (googleAccount == null || googleAccount.equals("")) {
             accountIdentity.setText(getResources().getString(R.string.no_account));
@@ -311,12 +312,12 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
       String[] credentialValues = getResources().getStringArray(R.array.credential_entry_values);
       String[] credentialEntries = getResources().getStringArray(R.array.credential_entries);
 
-      if ( credentialToUse == null ) {
+      if (credentialToUse == null) {
          credentialToUse = getString(R.string.credential_type_none);
       }
 
-      for ( int i = 0 ; i < credentialValues.length ; ++i ) {
-         if ( credentialToUse.equals(credentialValues[i]) ) {
+      for (int i = 0; i < credentialValues.length; ++i) {
+         if (credentialToUse.equals(credentialValues[i])) {
             if (!credentialToUse.equals(getString(R.string.credential_type_none))) {
                accountAuthType.setText(credentialEntries[i]);
             }
@@ -328,11 +329,11 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
       if (indexOfColon > 0) {
          account = account.substring(indexOfColon + 1);
       }
-      if ( credentialToUse.equals(getString(R.string.credential_type_none))) {
+      if (credentialToUse.equals(getString(R.string.credential_type_none))) {
          accountIdentity.setText(getResources().getString(R.string.anonymous));
-      } else if ( credentialToUse.equals(getString(R.string.credential_type_username_password))) {
+      } else if (credentialToUse.equals(getString(R.string.credential_type_username_password))) {
          accountIdentity.setText(account);
-      } else if ( credentialToUse.equals(getString(R.string.credential_type_google_account))) {
+      } else if (credentialToUse.equals(getString(R.string.credential_type_google_account))) {
          accountIdentity.setText(account);
       } else {
          accountIdentity.setText(getResources().getString(R.string.no_account));
@@ -348,7 +349,7 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
    private void perhapsEnableButtons() {
       PropertiesSingleton props = ((IOdkAppPropertiesActivity) this.getActivity()).getProps();
       String url = props.getProperty(CommonToolProperties.KEY_SYNC_SERVER_URL);
-      if ( url == null || url.length() == 0 ) {
+      if (url == null || url.length() == 0) {
          disableButtons();
       } else {
          authenticateNewUser.setEnabled(true);
@@ -412,6 +413,9 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
             loginAction = LoginActions.IDLE;
          }
          tickleInterface();
+      } else if (requestCode == RequestCodeConsts.RequestCodes.LAUNCH_CHECKPOINT_RESOLVER ||
+          requestCode == RequestCodeConsts.RequestCodes.LAUNCH_CONFLICT_RESOLVER) {
+         healthValidator.verifyTableHealth();
       }
    }
 
@@ -441,8 +445,8 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
                    final SyncStatus status = syncServiceInterface.getSyncStatus(getAppName());
                    final SyncProgressEvent event = syncServiceInterface
                        .getSyncProgressEvent(getAppName());
-                   WebLogger.getLogger(getAppName()).e(TAG,"tickleInterface status " + status.name() + " login "
-                       + "action " + loginAction.name());
+                   WebLogger.getLogger(getAppName()).e(TAG,
+                       "tickleInterface status " + status.name() + " login " + "action " + loginAction.name());
                    if (status == SyncStatus.SYNCING) {
                       loginAction = LoginActions.MONITOR_VERIFYING;
 
@@ -519,8 +523,8 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
                    final SyncStatus status = syncServiceInterface.getSyncStatus(getAppName());
                    final SyncProgressEvent event = syncServiceInterface
                        .getSyncProgressEvent(getAppName());
-                   WebLogger.getLogger(getAppName()).e(TAG,"updateInterface status " + status.name() + " login "
-                       + "action " + loginAction.name());
+                   WebLogger.getLogger(getAppName()).e(TAG,
+                       "updateInterface status " + status.name() + " login " + "action " + loginAction.name());
                    if (status == SyncStatus.SYNCING) {
                       loginAction = LoginActions.MONITOR_VERIFYING;
 
@@ -597,8 +601,7 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
                    updateInterface();
                    return;
                 } else {
-                   WebLogger.getLogger(getAppName())
-                       .i(TAG, "[" + getId() + "] [onSyncCompleted] and syncServiceInterface is null");
+                   WebLogger.getLogger(getAppName()).i(TAG, "[" + getId() + "] [onSyncCompleted] and syncServiceInterface is null");
                    handler.postDelayed(new Runnable() {
                       @Override
                       public void run() {
@@ -622,8 +625,7 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
          String password = props.getProperty(CommonToolProperties.KEY_PASSWORD);
          if (username == null || username.length() == 0 || password == null
              || password.length() == 0) {
-            SyncBaseActivity
-                .showAuthenticationErrorDialog(getActivity(), getString(R.string.sync_configure_username_password));
+            SyncBaseActivity.showAuthenticationErrorDialog(getActivity(), getString(R.string.sync_configure_username_password));
             return false;
          }
          return true;
@@ -631,8 +633,7 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
       if (getString(R.string.credential_type_google_account).equals(authType)) {
          String accountName = props.getProperty(CommonToolProperties.KEY_ACCOUNT);
          if (accountName == null || accountName.length() == 0) {
-            SyncBaseActivity
-                .showAuthenticationErrorDialog(getActivity(), getString(R.string.sync_configure_google_account));
+            SyncBaseActivity.showAuthenticationErrorDialog(getActivity(), getString(R.string.sync_configure_google_account));
             return false;
          }
          return true;
@@ -849,10 +850,9 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
             if (outcomeDialog != null) {
                dismissOutcomeDialog();
             }
-            outcomeDialog = DismissableOutcomeDialogFragment.newInstance(getString(id_title), message,
-                (status == SyncStatus.SYNC_COMPLETE
-                    || status == SyncStatus.SYNC_COMPLETE_PENDING_ATTACHMENTS),
-                LoginFragment.NAME);
+            outcomeDialog = DismissableOutcomeDialogFragment
+                .newInstance(getString(id_title), message, (status == SyncStatus.SYNC_COMPLETE
+                    || status == SyncStatus.SYNC_COMPLETE_PENDING_ATTACHMENTS), LoginFragment.NAME);
 
             // If fragment is not visible an exception could be thrown
             // TODO: Investigate a better way to handle this
@@ -916,5 +916,4 @@ public class LoginFragment extends Fragment implements ISyncOutcomeHandler {
       }
       return mAppName;
    }
-
 }

--- a/services_app/src/main/java/org/opendatakit/services/sync/actions/fragments/SyncFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/actions/fragments/SyncFragment.java
@@ -548,7 +548,6 @@ public class SyncFragment extends Fragment implements ISyncOutcomeHandler {
                   if (!completed) {
                     throw new IllegalStateException("Could not remove AppSynchronizer for " + getAppName());
                   }
-                  getActivity().finish();
                   return;
                 } else {
                   WebLogger.getLogger(getAppName()).i(TAG, "[" + getId() + "] [onSyncCompleted] and syncServiceInterface is null");

--- a/services_app/src/main/java/org/opendatakit/services/utilities/TableHealthValidator.java
+++ b/services_app/src/main/java/org/opendatakit/services/utilities/TableHealthValidator.java
@@ -1,0 +1,188 @@
+package org.opendatakit.services.utilities;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.ComponentName;
+import android.content.DialogInterface;
+import android.content.Intent;
+
+import org.opendatakit.consts.IntentConsts;
+import org.opendatakit.consts.RequestCodeConsts;
+import org.opendatakit.database.service.DbHandle;
+import org.opendatakit.database.utilities.CursorUtils;
+import org.opendatakit.logging.WebLogger;
+import org.opendatakit.services.R;
+import org.opendatakit.services.database.OdkConnectionFactorySingleton;
+import org.opendatakit.services.database.OdkConnectionInterface;
+import org.opendatakit.services.database.utlities.ODKDatabaseImplUtils;
+import org.opendatakit.services.sync.actions.activities.SyncActivity;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Check all tables in the database for changes, conflicts, or checkpoint rows. If a problem is
+ * found, prompt the user to resolve or ignore it.
+ */
+public class TableHealthValidator {
+
+    private static final String TAG = "TableHealthValidator";
+
+    private String appName;
+    private Activity displayActivity;
+
+    private List<String> checkpointTables;
+    private List<String> conflictTables;
+
+    public TableHealthValidator(String appName, Activity displayActivity) {
+        this.appName = appName;
+        this.displayActivity = displayActivity;
+    }
+
+    /**
+     * The control flow of this class is as follows:
+     *  1. User calls verifyTableHealth(). We check for all health issues.
+     *  2. If there are changes that need to be synced, promptToResolveChanges
+     *  3. After changes are resolved, if there are conflicts or checkpoints:
+     *     promptToResolveCheckpointsAndConflicts and then
+     *     resolveCheckpointsAndConflicts
+     */
+    public void verifyTableHealth() {
+        WebLogger.getLogger(appName).i(TAG, "[verifyTableHealth]");
+
+        OdkConnectionInterface db = null;
+        DbHandle dbHandleName = new DbHandle(UUID.randomUUID().toString());
+
+        checkpointTables = new LinkedList<>();
+        conflictTables = new LinkedList<>();
+        boolean hasChanges = false;
+
+        try {
+            // +1 referenceCount if db is returned (non-null)
+            db = OdkConnectionFactorySingleton.getOdkConnectionFactoryInterface()
+                    .getConnection(appName, dbHandleName);
+            List<String> tableIds = ODKDatabaseImplUtils.get().getAllTableIds(db);
+
+            for (String tableId : tableIds) {
+                int health = ODKDatabaseImplUtils.get().getTableHealth(db, tableId);
+
+                if (CursorUtils.getTableHealthIsClean(health)) {
+                    continue;
+                }
+
+                if (!hasChanges && CursorUtils.getTableHealthHasChanges(health)) {
+                    hasChanges = true;
+                }
+
+                if (CursorUtils.getTableHealthHasConflicts(health)) {
+                    conflictTables.add(tableId);
+                }
+
+                if (CursorUtils.getTableHealthHasCheckpoints(health)) {
+                    checkpointTables.add(tableId);
+                }
+            }
+        } finally {
+            if (db != null) {
+                // release the reference...
+                // this does not necessarily close the db handle
+                // or terminate any pending transaction
+                db.releaseReference();
+            }
+        }
+
+        WebLogger.getLogger(appName).i(TAG,
+                "[verifyTableHealth] " + "summary:\n\tUnsynced changes present: "
+                        + hasChanges + "\n\tNumber of conflict rows present: " + conflictTables.size()
+                        + "\n\tNumber of checkpoint rows present: " + checkpointTables.size());
+
+
+        if (hasChanges) {
+            promptToResolveChanges();
+        } else  {
+            checkForCheckpointAndConflictTables();
+        }
+    }
+
+    private void promptToResolveChanges() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(displayActivity);
+        builder.setTitle(R.string.sync_pending_changes);
+        builder.setMessage(R.string.resolve_pending_changes);
+        builder.setPositiveButton(R.string.ignore_changes, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int id) {
+                dialog.dismiss();
+                checkForCheckpointAndConflictTables();
+            }
+        });
+        builder.setNegativeButton(R.string.resolve_with_sync, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int id) {
+                dialog.dismiss();
+
+                // Launch the Sync activity to sync your changes.
+                // TODO: Can we check if we just came from sync and if so just return to that?
+                Intent i = new Intent(displayActivity, SyncActivity.class);
+                i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
+                displayActivity.startActivity(i);
+            }
+        });
+        AlertDialog dialog = builder.create();
+        dialog.show();
+    }
+
+    private void checkForCheckpointAndConflictTables() {
+
+        if ((checkpointTables != null && !checkpointTables.isEmpty()) ||
+                (conflictTables != null && !conflictTables.isEmpty())) {
+            promptToResolveCheckpointsAndConflicts();
+        }
+
+    }
+
+    private void promptToResolveCheckpointsAndConflicts() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(displayActivity);
+        builder.setTitle(R.string.resolve_checkpoints_and_conflicts);
+        builder.setMessage(R.string.resolve_pending_checkpoints_and_conflicts);
+        builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int id) {
+                dialog.dismiss();
+                resolveConflictsAndCheckpoints();
+            }
+        });
+        AlertDialog dialog = builder.create();
+        dialog.show();
+    }
+
+    private void resolveConflictsAndCheckpoints() {
+
+        if (checkpointTables != null && !checkpointTables.isEmpty()) {
+            Iterator<String> iterator = checkpointTables.iterator();
+            String tableId = iterator.next();
+            checkpointTables.remove(tableId);
+
+            Intent i;
+            i = new Intent();
+            i.setComponent(new ComponentName(IntentConsts.ResolveCheckpoint.APPLICATION_NAME,
+                    IntentConsts.ResolveCheckpoint.ACTIVITY_NAME));
+            i.setAction(Intent.ACTION_EDIT);
+            i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
+            i.putExtra(IntentConsts.INTENT_KEY_TABLE_ID, tableId);
+            displayActivity.startActivityForResult(i, RequestCodeConsts.RequestCodes.LAUNCH_CHECKPOINT_RESOLVER);
+        }
+        if (conflictTables != null && !conflictTables.isEmpty()) {
+            Iterator<String> iterator = conflictTables.iterator();
+            String tableId = iterator.next();
+            conflictTables.remove(tableId);
+
+            Intent i;
+            i = new Intent();
+            i.setComponent(new ComponentName(IntentConsts.ResolveConflict.APPLICATION_NAME,
+                    IntentConsts.ResolveConflict.ACTIVITY_NAME));
+            i.setAction(Intent.ACTION_EDIT);
+            i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
+            i.putExtra(IntentConsts.INTENT_KEY_TABLE_ID, tableId);
+            displayActivity.startActivityForResult(i, RequestCodeConsts.RequestCodes.LAUNCH_CONFLICT_RESOLVER);
+        }
+    }
+}

--- a/services_app/src/main/java/org/opendatakit/services/utilities/TableHealthValidator.java
+++ b/services_app/src/main/java/org/opendatakit/services/utilities/TableHealthValidator.java
@@ -28,161 +28,158 @@ import java.util.UUID;
  */
 public class TableHealthValidator {
 
-    private static final String TAG = "TableHealthValidator";
+  private static final String TAG = "TableHealthValidator";
 
-    private String appName;
-    private Activity displayActivity;
+  private String appName;
+  private Activity displayActivity;
 
-    private List<String> checkpointTables;
-    private List<String> conflictTables;
+  private List<String> checkpointTables;
+  private List<String> conflictTables;
 
-    public TableHealthValidator(String appName, Activity displayActivity) {
-        this.appName = appName;
-        this.displayActivity = displayActivity;
-    }
+  public TableHealthValidator(String appName, Activity displayActivity) {
+    this.appName = appName;
+    this.displayActivity = displayActivity;
+  }
 
-    /**
-     * The control flow of this class is as follows:
-     *  1. User calls verifyTableHealth(). We check for all health issues.
-     *  2. If there are changes that need to be synced, promptToResolveChanges
-     *  3. After changes are resolved, if there are conflicts or checkpoints:
-     *     promptToResolveCheckpointsAndConflicts and then
-     *     resolveCheckpointsAndConflicts
-     */
-    public void verifyTableHealth() {
-        WebLogger.getLogger(appName).i(TAG, "[verifyTableHealth]");
+  /**
+   * The control flow of this class is as follows:
+   *  1. User calls verifyTableHealth(). We check for all health issues.
+   *  2. If there are conflicts or checkpoints:
+   *     * promptToResolveCheckpointsAndConflicts and then
+   *     * resolveCheckpointsAndConflicts
+   *     * At this point, the user MUST override onActivityResult and call verifyTableHealth again.
+   *       This is because conflicts and checkpoints dirty the change data, so we need to resolve
+   *       them before we can check for unsynced changes.
+   *  3. If there are unsynced changes: promptToResolveChanges
+   */
 
-        OdkConnectionInterface db = null;
-        DbHandle dbHandleName = new DbHandle(UUID.randomUUID().toString());
+  public void verifyTableHealth() {
+    WebLogger.getLogger(appName).i(TAG, "[verifyTableHealth]");
 
-        checkpointTables = new LinkedList<>();
-        conflictTables = new LinkedList<>();
-        boolean hasChanges = false;
+    OdkConnectionInterface db = null;
+    DbHandle dbHandleName = new DbHandle(UUID.randomUUID().toString());
 
-        try {
-            // +1 referenceCount if db is returned (non-null)
-            db = OdkConnectionFactorySingleton.getOdkConnectionFactoryInterface()
-                    .getConnection(appName, dbHandleName);
-            List<String> tableIds = ODKDatabaseImplUtils.get().getAllTableIds(db);
+    checkpointTables = new LinkedList<>();
+    conflictTables = new LinkedList<>();
+    boolean hasChanges = false;
 
-            for (String tableId : tableIds) {
-                int health = ODKDatabaseImplUtils.get().getTableHealth(db, tableId);
+    try {
+      // +1 referenceCount if db is returned (non-null)
+      db = OdkConnectionFactorySingleton.getOdkConnectionFactoryInterface()
+          .getConnection(appName, dbHandleName);
+      List<String> tableIds = ODKDatabaseImplUtils.get().getAllTableIds(db);
 
-                if (CursorUtils.getTableHealthIsClean(health)) {
-                    continue;
-                }
+      for (String tableId : tableIds) {
+        int health = ODKDatabaseImplUtils.get().getTableHealth(db, tableId);
 
-                if (!hasChanges && CursorUtils.getTableHealthHasChanges(health)) {
-                    hasChanges = true;
-                }
-
-                if (CursorUtils.getTableHealthHasConflicts(health)) {
-                    conflictTables.add(tableId);
-                }
-
-                if (CursorUtils.getTableHealthHasCheckpoints(health)) {
-                    checkpointTables.add(tableId);
-                }
-            }
-        } finally {
-            if (db != null) {
-                // release the reference...
-                // this does not necessarily close the db handle
-                // or terminate any pending transaction
-                db.releaseReference();
-            }
+        if (CursorUtils.getTableHealthIsClean(health)) {
+          continue;
         }
 
-        WebLogger.getLogger(appName).i(TAG,
-                "[verifyTableHealth] " + "summary:\n\tUnsynced changes present: "
-                        + hasChanges + "\n\tNumber of conflict rows present: " + conflictTables.size()
-                        + "\n\tNumber of checkpoint rows present: " + checkpointTables.size());
-
-
-        if (hasChanges) {
-            promptToResolveChanges();
-        } else  {
-            checkForCheckpointAndConflictTables();
-        }
-    }
-
-    private void promptToResolveChanges() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(displayActivity);
-        builder.setTitle(R.string.sync_pending_changes);
-        builder.setMessage(R.string.resolve_pending_changes);
-        builder.setPositiveButton(R.string.ignore_changes, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                dialog.dismiss();
-                checkForCheckpointAndConflictTables();
-            }
-        });
-        builder.setNegativeButton(R.string.resolve_with_sync, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                dialog.dismiss();
-
-                // Launch the Sync activity to sync your changes.
-                // TODO: Can we check if we just came from sync and if so just return to that?
-                Intent i = new Intent(displayActivity, SyncActivity.class);
-                i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
-                displayActivity.startActivity(i);
-            }
-        });
-        AlertDialog dialog = builder.create();
-        dialog.show();
-    }
-
-    private void checkForCheckpointAndConflictTables() {
-
-        if ((checkpointTables != null && !checkpointTables.isEmpty()) ||
-                (conflictTables != null && !conflictTables.isEmpty())) {
-            promptToResolveCheckpointsAndConflicts();
+        if (!hasChanges && CursorUtils.getTableHealthHasChanges(health)) {
+          hasChanges = true;
         }
 
-    }
-
-    private void promptToResolveCheckpointsAndConflicts() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(displayActivity);
-        builder.setTitle(R.string.resolve_checkpoints_and_conflicts);
-        builder.setMessage(R.string.resolve_pending_checkpoints_and_conflicts);
-        builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                dialog.dismiss();
-                resolveConflictsAndCheckpoints();
-            }
-        });
-        AlertDialog dialog = builder.create();
-        dialog.show();
-    }
-
-    private void resolveConflictsAndCheckpoints() {
-
-        if (checkpointTables != null && !checkpointTables.isEmpty()) {
-            Iterator<String> iterator = checkpointTables.iterator();
-            String tableId = iterator.next();
-            checkpointTables.remove(tableId);
-
-            Intent i;
-            i = new Intent();
-            i.setComponent(new ComponentName(IntentConsts.ResolveCheckpoint.APPLICATION_NAME,
-                    IntentConsts.ResolveCheckpoint.ACTIVITY_NAME));
-            i.setAction(Intent.ACTION_EDIT);
-            i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
-            i.putExtra(IntentConsts.INTENT_KEY_TABLE_ID, tableId);
-            displayActivity.startActivityForResult(i, RequestCodeConsts.RequestCodes.LAUNCH_CHECKPOINT_RESOLVER);
+        if (CursorUtils.getTableHealthHasConflicts(health)) {
+          conflictTables.add(tableId);
         }
-        if (conflictTables != null && !conflictTables.isEmpty()) {
-            Iterator<String> iterator = conflictTables.iterator();
-            String tableId = iterator.next();
-            conflictTables.remove(tableId);
 
-            Intent i;
-            i = new Intent();
-            i.setComponent(new ComponentName(IntentConsts.ResolveConflict.APPLICATION_NAME,
-                    IntentConsts.ResolveConflict.ACTIVITY_NAME));
-            i.setAction(Intent.ACTION_EDIT);
-            i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
-            i.putExtra(IntentConsts.INTENT_KEY_TABLE_ID, tableId);
-            displayActivity.startActivityForResult(i, RequestCodeConsts.RequestCodes.LAUNCH_CONFLICT_RESOLVER);
+        if (CursorUtils.getTableHealthHasCheckpoints(health)) {
+          checkpointTables.add(tableId);
         }
+      }
+    } finally {
+      if (db != null) {
+        // release the reference...
+        // this does not necessarily close the db handle
+        // or terminate any pending transaction
+        db.releaseReference();
+      }
     }
+
+    WebLogger.getLogger(appName).i(TAG,
+        "[verifyTableHealth] " + "summary:\n\tUnsynced changes present: "
+            + hasChanges + "\n\tNumber of conflict rows present: " + conflictTables.size()
+            + "\n\tNumber of checkpoint rows present: " + checkpointTables.size());
+
+
+    if ((checkpointTables != null && !checkpointTables.isEmpty()) ||
+        (conflictTables != null && !conflictTables.isEmpty())) {
+      promptToResolveCheckpointsAndConflicts();
+    } else if (hasChanges) {
+      promptToResolveChanges();
+    }
+  }
+
+  private void promptToResolveChanges() {
+    AlertDialog.Builder builder = new AlertDialog.Builder(displayActivity);
+    builder.setTitle(R.string.sync_pending_changes);
+    builder.setMessage(R.string.resolve_pending_changes);
+    builder.setPositiveButton(R.string.ignore_changes, new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int id) {
+        dialog.dismiss();
+        // Proceed to change authentications unhindered. We have warned the user and they chose to
+        // take a risk.
+      }
+    });
+    builder.setNegativeButton(R.string.resolve_with_sync, new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int id) {
+        dialog.dismiss();
+
+        // Launch the Sync activity to sync your changes.
+        // TODO: Can we check if we just came from sync and if so just return to that?
+        Intent i = new Intent(displayActivity, SyncActivity.class);
+        i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
+        displayActivity.startActivity(i);
+      }
+    });
+    AlertDialog dialog = builder.create();
+    dialog.show();
+  }
+
+  private void promptToResolveCheckpointsAndConflicts() {
+    AlertDialog.Builder builder = new AlertDialog.Builder(displayActivity);
+    builder.setTitle(R.string.resolve_checkpoints_and_conflicts);
+    builder.setMessage(R.string.resolve_pending_checkpoints_and_conflicts);
+    builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int id) {
+        dialog.dismiss();
+        resolveConflictsAndCheckpoints();
+      }
+    });
+    AlertDialog dialog = builder.create();
+    dialog.show();
+  }
+
+  private void resolveConflictsAndCheckpoints() {
+
+    if (checkpointTables != null && !checkpointTables.isEmpty()) {
+      Iterator<String> iterator = checkpointTables.iterator();
+      String tableId = iterator.next();
+      checkpointTables.remove(tableId);
+
+      Intent i;
+      i = new Intent();
+      i.setComponent(new ComponentName(IntentConsts.ResolveCheckpoint.APPLICATION_NAME,
+          IntentConsts.ResolveCheckpoint.ACTIVITY_NAME));
+      i.setAction(Intent.ACTION_EDIT);
+      i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
+      i.putExtra(IntentConsts.INTENT_KEY_TABLE_ID, tableId);
+      displayActivity.startActivityForResult(i, RequestCodeConsts.RequestCodes.LAUNCH_CHECKPOINT_RESOLVER);
+    }
+    if (conflictTables != null && !conflictTables.isEmpty()) {
+      Iterator<String> iterator = conflictTables.iterator();
+      String tableId = iterator.next();
+      conflictTables.remove(tableId);
+
+      Intent i;
+      i = new Intent();
+      i.setComponent(new ComponentName(IntentConsts.ResolveConflict.APPLICATION_NAME,
+          IntentConsts.ResolveConflict.ACTIVITY_NAME));
+      i.setAction(Intent.ACTION_EDIT);
+      i.putExtra(IntentConsts.INTENT_KEY_APP_NAME, appName);
+      i.putExtra(IntentConsts.INTENT_KEY_TABLE_ID, tableId);
+      displayActivity.startActivityForResult(i, RequestCodeConsts.RequestCodes.LAUNCH_CONFLICT_RESOLVER);
+    }
+  }
 }

--- a/services_app/src/main/res/layout/login_fragment.xml
+++ b/services_app/src/main/res/layout/login_fragment.xml
@@ -5,17 +5,6 @@
               android:orientation="vertical">
 
     <TextView
-        android:id="@+id/warn_sync_before_logout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"
-        android:layout_marginTop="5dp"
-        android:textSize="20sp"
-        android:textColor="@color/red"
-        android:text="@string/sync_warn_sync_before_logout"/>
-
-    <TextView
             android:id="@+id/sync_uri_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/services_app/src/main/res/values/strings.xml
+++ b/services_app/src/main/res/values/strings.xml
@@ -270,6 +270,9 @@
     <string name="resolve_with_sync">Sync Changes</string>
     <string name="ignore_changes">Ignore Unsynced Changes</string>
 
+    <string name="resolve_checkpoints_and_conflicts">Resolve Checkpoints and Conflicts</string>
+    <string name="resolve_pending_checkpoints_and_conflicts">You have checkpoint rows and/or conflicts with the server that must be resolved before you can change your authenticated user.</string>
+
     <string name="anonymous_warning">Authenticate new credentials?\r\n\r\nWarning: If
         you choose not verify your credentials you will be logged out.</string>
     <string name="authentication_error">Authentication Error</string>

--- a/services_app/src/main/res/values/strings.xml
+++ b/services_app/src/main/res/values/strings.xml
@@ -184,8 +184,6 @@
     <string name="sync_defer_instance_files">Defer Instance Attachments</string>
     <string name="sync_start">Sync now</string>
     <string name="sync_reset_server">Reset App Server</string>
-    <string name="sync_warn_sync_before_logout">WARNING: Be sure to sync before changing
-        users or logging out</string>
 
     <string name="sync_confirm_change_settings">Confirm Change Settings</string>
     <string name="sync_change_settings_warning">If you change your settings, tables you have sync\'d now may no longer be able to be sync\'d.</string>

--- a/services_app/src/main/res/values/strings.xml
+++ b/services_app/src/main/res/values/strings.xml
@@ -268,7 +268,7 @@
         the server. If you change users or logout before syncing these changes, you may
         lose them.</string>
     <string name="resolve_with_sync">Sync Changes</string>
-    <string name="ignore_changes">Discard Unsynced Changes</string>
+    <string name="ignore_changes">Ignore Unsynced Changes</string>
 
     <string name="anonymous_warning">Authenticate new credentials?\r\n\r\nWarning: If
         you choose not verify your credentials you will be logged out.</string>

--- a/services_app/src/main/res/values/strings.xml
+++ b/services_app/src/main/res/values/strings.xml
@@ -263,6 +263,13 @@
     <string name="logout">Log Out</string>
     <string name="authenticate_credentials">Authenticate Credentials</string>
 
+    <string name="sync_pending_changes">Sync Pending Changes</string>
+    <string name="resolve_pending_changes">You have changes that have not been synced to
+        the server. If you change users or logout before syncing these changes, you may
+        lose them.</string>
+    <string name="resolve_with_sync">Sync Changes</string>
+    <string name="ignore_changes">Discard Unsynced Changes</string>
+
     <string name="anonymous_warning">Authenticate new credentials?\r\n\r\nWarning: If
         you choose not verify your credentials you will be logged out.</string>
     <string name="authentication_error">Authentication Error</string>


### PR DESCRIPTION
When a user enters the login screen or the server settings page, this change will check to see if there are any unsynced changes and if there are any conflicts or checkpoints. If there are unsynced changes, the user will be prompted to sync their changes or ignore the unsynced changes at their own risk. If there are conflicts and/or checkpoints, the normal conflict and checkpoint resolution activities will be launched. 

This pull request is a prerequisite: https://github.com/opendatakit/androidlibrary/pull/10