### PR TITLE
handle privilege-loss by silently deleting outstanding checkpoints on…

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/database/utlities/ODKDatabaseImplUtils.java
+++ b/services_app/src/main/java/org/opendatakit/services/database/utlities/ODKDatabaseImplUtils.java
@@ -2708,9 +2708,10 @@ public final class ODKDatabaseImplUtils {
 
     AccessContext accessContext = getAccessContext(db, tableId, activeUser, rolesList);
 
-    return query(db, tableId, QueryUtil.buildSqlStatement(tableId, QueryUtil.GET_ROWS_WITH_ID_WHERE,
-        QueryUtil.GET_ROWS_WITH_ID_GROUP_BY, QueryUtil.GET_ROWS_WITH_ID_HAVING,
-        QueryUtil.GET_ROWS_WITH_ID_ORDER_BY_KEYS, QueryUtil.GET_ROWS_WITH_ID_ORDER_BY_DIR),
+    return query(db, tableId, QueryUtil.buildSqlStatement(tableId,
+        QueryUtil.WHERE_CLAUSE_ROWS_WITH_ID_EQUALS,
+        null, null,
+        QueryUtil.ORDER_BY_SAVEPOINT_TIMESTAMP, QueryUtil.ORDER_BY_DESCENDING),
         new String[] { rowId }, null, accessContext);
   }
 
@@ -2732,9 +2733,9 @@ public final class ODKDatabaseImplUtils {
         RoleConsts.ADMIN_ROLES_LIST);
 
     return privilegedQuery(db, tableId, QueryUtil
-            .buildSqlStatement(tableId, QueryUtil.GET_ROWS_WITH_ID_WHERE,
-                QueryUtil.GET_ROWS_WITH_ID_GROUP_BY, QueryUtil.GET_ROWS_WITH_ID_HAVING,
-                QueryUtil.GET_ROWS_WITH_ID_ORDER_BY_KEYS, QueryUtil.GET_ROWS_WITH_ID_ORDER_BY_DIR),
+            .buildSqlStatement(tableId, QueryUtil.WHERE_CLAUSE_ROWS_WITH_ID_EQUALS,
+                null, null,
+                QueryUtil.ORDER_BY_SAVEPOINT_TIMESTAMP, QueryUtil.ORDER_BY_DESCENDING),
         new String[] { rowId }, null, accessContext);
   }
 

--- a/services_app/src/main/java/org/opendatakit/services/resolve/checkpoint/CheckpointResolutionListFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/resolve/checkpoint/CheckpointResolutionListFragment.java
@@ -183,6 +183,20 @@ public class CheckpointResolutionListFragment extends ListFragment implements Lo
     // we have resolved the metadata conflicts -- no need to try this again
     mHaveResolvedMetadataConflicts = true;
 
+    // this toast may be silently swallowed if there is only one remaining checkpoint in the table.
+    int silentlyResolvedCheckpoints =
+        ((OdkResolveCheckpointRowLoader) loader).getNumberRowsSilentlyReverted();
+
+    if ( silentlyResolvedCheckpoints != 0 ) {
+      if ( silentlyResolvedCheckpoints == 1 ) {
+        Toast.makeText(getActivity(), getActivity().getString(R.string
+                .silently_resolved_single_checkpoint), Toast.LENGTH_LONG).show();
+      } else {
+        Toast.makeText(getActivity(), getActivity().getString(R.string.silently_resolved_checkpoints,
+            silentlyResolvedCheckpoints), Toast.LENGTH_LONG).show();
+      }
+    }
+
     // Swap the new cursor in. (The framework will take care of closing the
     // old cursor once we return.)
     mAdapter.clear();

--- a/services_app/src/main/java/org/opendatakit/services/resolve/checkpoint/OdkResolveCheckpointRowLoader.java
+++ b/services_app/src/main/java/org/opendatakit/services/resolve/checkpoint/OdkResolveCheckpointRowLoader.java
@@ -43,9 +43,7 @@ import org.opendatakit.services.resolve.views.components.ResolveActionList;
 import org.opendatakit.services.resolve.views.components.ResolveRowEntry;
 import org.opendatakit.services.R;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * @author mitchellsundt@gmail.com
@@ -55,6 +53,7 @@ class OdkResolveCheckpointRowLoader extends AsyncTaskLoader<ArrayList<ResolveRow
   private final String mAppName;
   private final String mTableId;
   private final boolean mHaveResolvedMetadataConflicts;
+  private int mNumberRowsSilentlyReverted = 0;
 
   private static class FormDefinition {
     String instanceName;
@@ -68,6 +67,10 @@ class OdkResolveCheckpointRowLoader extends AsyncTaskLoader<ArrayList<ResolveRow
     this.mAppName = appName;
     this.mTableId = tableId;
     this.mHaveResolvedMetadataConflicts = haveResolvedMetadataConflicts;
+  }
+
+  public int getNumberRowsSilentlyReverted() {
+    return mNumberRowsSilentlyReverted;
   }
 
   @Override
@@ -137,14 +140,60 @@ class OdkResolveCheckpointRowLoader extends AsyncTaskLoader<ArrayList<ResolveRow
 
           if (resolveActionList.noChangesInUserDefinedFieldValues()) {
             tableSetChanged = true;
+            // act as a privileged user so that we always restore to original row
             ODKDatabaseImplUtils.deleteAllCheckpointRowsWithId(db, mTableId,
-                rowId, aul.activeUser, aul.rolesList);
+                rowId, aul.activeUser, RoleConsts.ADMIN_ROLES_LIST);
           }
         }
 
         if ( tableSetChanged ) {
           baseTable = ODKDatabaseImplUtils.privilegedQuery(db, mTableId, QueryUtil
               .buildSqlStatement(mTableId, whereClause, groupBy, null, orderByKeys, orderByDir),
+              null, null, accessContextPrivileged);
+          table = new UserTable(baseTable, orderedDefns, adminColArr);
+        }
+      }
+
+      // Now run the same query --  but as an unprivileged query (with the current user's
+      // permissions).
+      // Then construct a set of ids that were returned by the privileged query but that were
+      // either not in the unprivileged result set (i.e., are hidden to this user) or for which
+      // the current user does not have modify ("w") access. Revert these, as the user does not
+      // have permission to modify them. And, finally, if that set is non-empty, re-fetch the
+      // table, as it will now have fewer rows.
+      {
+        BaseTable unprivilegedBaseTable = ODKDatabaseImplUtils.query(db, mTableId, QueryUtil
+                .buildSqlStatement(mTableId, whereClause, groupBy, null, orderByKeys, orderByDir), null,
+            null, accessContextBase);
+        UserTable unprivilegedTable = new UserTable(unprivilegedBaseTable, orderedDefns, adminColArr);
+
+        // build up the set of ids missing from the unprivilegedTable vs. the (privilegedQuery)
+        // table and any ids that the user does not have the ability to modify ("w" access).
+        Set<String> ids = new HashSet<String>();
+        for (int i = 0; i < table.getNumberOfRows(); ++i) {
+          ids.add(table.getRowId(i));
+        }
+        for (int i = 0; i < unprivilegedTable.getNumberOfRows(); ++i) {
+          Row theRow = unprivilegedTable.getRowAtIndex(i);
+          // only display a checkpoint if the user is able to modify the row
+          if (theRow.getDataByKey(DataTableColumns.EFFECTIVE_ACCESS).contains("w")) {
+            ids.remove(unprivilegedTable.getRowId(i));
+          }
+        }
+        mNumberRowsSilentlyReverted = ids.size();
+
+        // the ids remaining in 'ids' are either hidden to the user or the user does not have
+        // the ability to modify those rows. Resolve all of these by deleting the checkpoints.
+        for (String rowId : ids) {
+          // act as a privileged user so that we always restore to original row
+          ODKDatabaseImplUtils.deleteAllCheckpointRowsWithId(db, mTableId, rowId, aul.activeUser,
+              RoleConsts.ADMIN_ROLES_LIST);
+        }
+
+        if ( mNumberRowsSilentlyReverted != 0 ) {
+          // update the privileged query table again
+          baseTable = ODKDatabaseImplUtils.privilegedQuery(db, mTableId, QueryUtil
+                  .buildSqlStatement(mTableId, whereClause, groupBy, null, orderByKeys, orderByDir),
               null, null, accessContextPrivileged);
           table = new UserTable(baseTable, orderedDefns, adminColArr);
         }

--- a/services_app/src/main/java/org/opendatakit/services/resolve/task/CheckpointResolutionListTask.java
+++ b/services_app/src/main/java/org/opendatakit/services/resolve/task/CheckpointResolutionListTask.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.AsyncTask;
 import android.widget.ArrayAdapter;
 
+import org.opendatakit.database.RoleConsts;
 import org.opendatakit.services.database.OdkConnectionFactorySingleton;
 import org.opendatakit.services.database.OdkConnectionInterface;
 import org.opendatakit.services.database.utlities.ODKDatabaseImplUtils;
@@ -64,11 +65,13 @@ public class CheckpointResolutionListTask extends AsyncTask<Void, String, String
         try {
 
           if ( mTakeNewest ) {
+            // this may fail if user does not have permissions for modifying row
             ODKDatabaseImplUtils
                 .saveAsCompleteMostRecentCheckpointRowWithId(db, mTableId, entry.rowId);
           } else {
+            // allow all users to automatically roll back
             ODKDatabaseImplUtils.deleteAllCheckpointRowsWithId(db, mTableId,
-                entry.rowId, aul.activeUser, aul.rolesList);
+                entry.rowId, aul.activeUser, RoleConsts.ADMIN_ROLES_LIST);
           }
 
         } catch (Exception e) {

--- a/services_app/src/main/res/values/strings.xml
+++ b/services_app/src/main/res/values/strings.xml
@@ -43,6 +43,10 @@
     <string name="no_items_display_checkpoints">Please wait&#8230;\nSearching for checkpoint rows to resolve.</string>
     <string name="checkpoint_take_all_oldest_or_remove">Discard All Checkpoints</string>
     <string name="checkpoint_take_all_newest">Update All Checkpoints to Incomplete State</string>
+    <string name="silently_resolved_single_checkpoint">a checkpoint on an unmodifiable row was
+        silently rolled back.</string>
+    <string name="silently_resolved_checkpoints">%1$d checkpoints on unmodifiable rows were
+        silently rolled back.</string>
 
     <string name="checkpoint_radio_local">Apply:</string>
     <string name="checkpoint_radio_server">Restore:</string>


### PR DESCRIPTION
This is dependent upon this pull  request:

#https://github.com/opendatakit/androidlibrary/pull/11

This enables the system to automatically delete any checkpoints when a user loses permissions to view or change a row. Without this change, the system can get into an infinite flashing refresh where it toggles between ODK Tables and ODK Services resolution screens and cannot be exited.

To reproduce the original error, install all the ODK tools. And:
    `grunt adbpush-tables-rowlevelaccessdemo`
from app-designer.

And reset a server with this demo configuration.

Then, as the tables superuser or higher, open *ODK Survey* and open the `Weather Conditions for Geo-Weather Survey` form.

Edit the `Raining` or `Light rain (drizzle)` instances. Change anything on these rows. 

Advance off the screen to the finalize screen, and then show list-of-open-apps, and close *ODK Survey* via that screen or open Apps and force close. This leaves a checkpoint in this table. These rows are tagged as read-only (Rain) or hidden (Drizzle) for non-privileged users. 

You can verify that these checkpoints are created by going to *ODK Services* and choosing to change user or log out -- you will be warned about checkpoints, and will see 2 checkpoints. Once again show the list-of-apps and close *ODK Services*.  Now open *ODK Services* and go to `Settings / Reset Configuration`. This will clear the active user, setting the user back to anonymous and therefore unprivileged. 

If you have not applied the csv import patch in androidlibrary (dependent pull request), when you open *ODK Tables*, it will force close. With the patch, it will open, drop into the checkpoint resolution screens, and display a toast reporting that one or 2 checkpoints were resolved silently (deleted) because you don't have write privileges on those rows.
