### PR TITLE
conflict resolution fix for loss-of-privilege case

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/database/utlities/ODKDatabaseImplUtils.java
+++ b/services_app/src/main/java/org/opendatakit/services/database/utlities/ODKDatabaseImplUtils.java
@@ -3327,7 +3327,7 @@ public final class ODKDatabaseImplUtils {
    * @param locale               the users selected locale
    * @return true if we are still in conflict
    */
-  private static boolean enforcePermissionsAndOptimizeConflictProcessing(OdkConnectionInterface db,
+  public static boolean enforcePermissionsAndOptimizeConflictProcessing(OdkConnectionInterface db,
       String tableId, OrderedColumns orderedColumns, String rowId, SyncState initialLocalRowState,
       AccessContext accessContext, String locale) {
 

--- a/services_app/src/main/java/org/opendatakit/services/resolve/conflict/ConflictResolutionListFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/resolve/conflict/ConflictResolutionListFragment.java
@@ -183,6 +183,20 @@ public class ConflictResolutionListFragment extends ListFragment implements Load
     // we have resolved the metadata conflicts -- no need to try this again
     mHaveResolvedMetadataConflicts = true;
 
+    // this toast may be silently swallowed if there is only one remaining checkpoint in the table.
+    int silentlyResolvedConflicts =
+        ((OdkResolveConflictRowLoader) loader).getNumberRowsSilentlyResolved();
+
+    if ( silentlyResolvedConflicts != 0 ) {
+      if ( silentlyResolvedConflicts == 1 ) {
+        Toast.makeText(getActivity(), getActivity().getString(R.string
+            .silently_resolved_single_conflict), Toast.LENGTH_LONG).show();
+      } else {
+        Toast.makeText(getActivity(), getActivity().getString(R.string.silently_resolved_conflicts,
+            silentlyResolvedConflicts), Toast.LENGTH_LONG).show();
+      }
+    }
+
     // Swap the new cursor in. (The framework will take care of closing the
     // old cursor once we return.)
     mAdapter.clear();

--- a/services_app/src/main/java/org/opendatakit/services/resolve/conflict/OdkResolveConflictRowLoader.java
+++ b/services_app/src/main/java/org/opendatakit/services/resolve/conflict/OdkResolveConflictRowLoader.java
@@ -18,6 +18,7 @@ package org.opendatakit.services.resolve.conflict;
 import android.content.AsyncTaskLoader;
 import android.content.Context;
 import android.database.Cursor;
+import org.opendatakit.aggregate.odktables.rest.SyncState;
 import org.opendatakit.database.RoleConsts;
 import org.opendatakit.aggregate.odktables.rest.ConflictType;
 import org.opendatakit.aggregate.odktables.rest.KeyValueStoreConstants;
@@ -41,9 +42,7 @@ import org.opendatakit.database.utilities.QueryUtil;
 import org.opendatakit.services.resolve.views.components.ResolveActionList;
 import org.opendatakit.services.resolve.views.components.ResolveRowEntry;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * @author mitchellsundt@gmail.com
@@ -53,6 +52,7 @@ class OdkResolveConflictRowLoader extends AsyncTaskLoader<ArrayList<ResolveRowEn
   private final String mAppName;
   private final String mTableId;
   private final boolean mHaveResolvedMetadataConflicts;
+  private int mNumberRowsSilentlyResolved = 0;
 
   private static class FormDefinition {
     String instanceName;
@@ -66,6 +66,10 @@ class OdkResolveConflictRowLoader extends AsyncTaskLoader<ArrayList<ResolveRowEn
     this.mAppName = appName;
     this.mTableId = tableId;
     this.mHaveResolvedMetadataConflicts = haveResolvedMetadataConflicts;
+  }
+
+  public int getNumberRowsSilentlyResolved() {
+    return mNumberRowsSilentlyResolved;
   }
 
   @Override public ArrayList<ResolveRowEntry> loadInBackground() {
@@ -98,6 +102,10 @@ class OdkResolveConflictRowLoader extends AsyncTaskLoader<ArrayList<ResolveRowEn
       List<String> adminColumns = ODKDatabaseImplUtils.getAdminColumns();
       String[] adminColArr = adminColumns.toArray(new String[adminColumns.size()]);
 
+      ODKDatabaseImplUtils.AccessContext accessContextBase =
+          ODKDatabaseImplUtils.getAccessContext(db, mTableId, aul.activeUser,
+              aul.rolesList);
+
       ODKDatabaseImplUtils.AccessContext accessContextPrivileged =
           ODKDatabaseImplUtils.getAccessContext(db, mTableId, aul.activeUser,
               RoleConsts.ADMIN_ROLES_LIST);
@@ -107,6 +115,127 @@ class OdkResolveConflictRowLoader extends AsyncTaskLoader<ArrayList<ResolveRowEn
           selectionArgs, null, accessContextPrivileged);
       table = new UserTable(baseTable, orderedDefns, adminColArr);
 
+      // NOTE: Logic is slightly different from checkpoints, as the privilege-change logic below
+      // may alter the permissions fields of a row (force the server's permissions into the local
+      // change).  We therefore make the if-no-changes clean-up after this logic, rather than
+      // before it.
+
+      // Now run a similar query, but pulling the server conflict records as an unprivileged
+      // query (with the current user's permissions). This gets the effectiveAccess (**from the
+      // server change**) that the user would have when resolving a conflict. If the user does
+      // not have "w" access and is trying to do a local update, or if the user does not have
+      // "d" access and is trying to do a local delete, then the conflict should be resolved by
+      // taking the server's change.
+      //
+      // i.e., the server conflict row imposes its privilege restrictions prior to consideration
+      // of the user's row changes. So a change from the server can revoke privileges for a
+      // class of users, and, when resolving conflicts, any users whose privileges have been
+      // revoked should be forced to take the server's changes. This happens implicitly in the
+      // ODKDatabaseImplUtils.privilegedPerhapsPlaceRowIntoConflictWithId() method. We apply
+      // that same logic here to handle loss-of-privilege between the time of Sync and the time
+      // we hit this conflict-resolution screen.
+      //
+      // We also enforce permissions-change restrictions on all of the local conflicts. This
+      // makes it necessary to always re-fetch the table whether or not the number of conflicts
+      // has actually changed (unlike in the checkpoint resolution case).
+      //
+      // For bookkeeping, we first create a map of rowId -> local conflict type
+      // and then iterate over the result set from the server query.
+      {
+        // create a map of rowId -> local conflict type from the privileged query.
+        //
+        // then build up the set of ids missing from the unprivilegedTable vs. the (privilegedQuery)
+        // table and any ids that the user does not have the ability to modify ("w" access) or
+        // delete ("d" access) as appropriate for the conflict type.
+        HashMap<String, Integer> localConflictTypeMap = new HashMap<>();
+        Set<String> ids = new HashSet<String>();
+        for (int i = 0; i < table.getNumberOfRows(); ++i) {
+          // full set of ids in conflict
+          ids.add(table.getRowId(i));
+          Row theRow = table.getRowAtIndex(i);
+          String strLocalConflictValue = theRow.getDataByKey(DataTableColumns.CONFLICT_TYPE);
+          // the strLocalConflictValue will always be an integer because of the where clause
+          int localConflictValue = Integer.valueOf(strLocalConflictValue);
+          localConflictTypeMap.put(table.getRowId(i), localConflictValue);
+        }
+
+        int removedRows = 0;
+
+        // do the unprivileged query to get the server rows
+        Object[] serverSelectionArgs = new Object[] {
+            ConflictType.SERVER_DELETED_OLD_VALUES, ConflictType.SERVER_UPDATED_UPDATED_VALUES };
+        BaseTable unprivilegedBaseTable = ODKDatabaseImplUtils.query(db, mTableId, QueryUtil
+                .buildSqlStatement(mTableId, whereClause, groupBy, null, orderByKeys, orderByDir),
+            serverSelectionArgs, null, accessContextBase);
+        UserTable unprivilegedTable = new UserTable(unprivilegedBaseTable, orderedDefns, adminColArr);
+
+        for (int i = 0; i < unprivilegedTable.getNumberOfRows(); ++i) {
+          String rowId = unprivilegedTable.getRowId(i);
+          // fetch the local conflict value from the map created above.
+          // there will always be a value because the localConflictTypeMap was built
+          // from results of a privileged query. The unprivileged query is always
+          // a subset of the privileged query result set.
+          int localConflictValue = localConflictTypeMap.get(rowId);
+
+          Row theRow = unprivilegedTable.getRowAtIndex(i);
+          String effectiveAccess = theRow.getDataByKey(DataTableColumns.EFFECTIVE_ACCESS);
+
+          if ( localConflictValue == ConflictType.LOCAL_UPDATED_UPDATED_VALUES &&
+               effectiveAccess.contains("w") ) {
+            // local update and user can modify the row -- do not auto-resolve this
+            // HOWEVER: enforce permissions-update rules (whether the user has "p" privileges)
+            // this may resolve the conflict...
+            if ( !ODKDatabaseImplUtils.enforcePermissionsAndOptimizeConflictProcessing
+                (db, mTableId, orderedDefns, rowId, SyncState.in_conflict,
+                    accessContextBase, aul.locale) ) {
+              ++removedRows;
+            }
+            // and then present it to the user (remove it from this list).
+            ids.remove(rowId);
+          } else if ( localConflictValue == ConflictType.LOCAL_DELETED_OLD_VALUES &&
+               effectiveAccess.contains("d") ) {
+            // local delete and user can delete the row -- do not auto-resolve this
+            // HOWEVER: enforce permissions-update rules (whether the user has "p" privileges)
+            // this may resolve the conflict...
+            if ( !ODKDatabaseImplUtils.enforcePermissionsAndOptimizeConflictProcessing
+                (db, mTableId, orderedDefns, rowId, SyncState.in_conflict,
+                    accessContextBase, aul.locale) ) {
+              ++removedRows;
+            }
+            // and then present it to the user (remove it from this list).
+            ids.remove(rowId);
+          }
+        }
+        mNumberRowsSilentlyResolved = ids.size() + removedRows;
+
+        // the ids remaining in 'ids' are either hidden to the user or the user does not have
+        // the ability to perform the local change they want in those rows.
+        for (String rowId : ids) {
+          // act as a privileged user so that we always restore to original row
+          ODKDatabaseImplUtils.resolveServerConflictTakeServerRowWithId(db, mTableId, rowId,
+              aul.activeUser, RoleConsts.ADMIN_ROLES_LIST);
+        }
+
+        {
+          // update the privileged query table again
+          // we always do this because we may have updated the permissions fields
+          selectionArgs = new Object[] { ConflictType.LOCAL_DELETED_OLD_VALUES,
+              ConflictType.LOCAL_UPDATED_UPDATED_VALUES };
+
+          baseTable = ODKDatabaseImplUtils.privilegedQuery(db, mTableId, QueryUtil
+                  .buildSqlStatement(mTableId, whereClause, groupBy, null, orderByKeys, orderByDir),
+              selectionArgs, null, accessContextPrivileged);
+          table = new UserTable(baseTable, orderedDefns, adminColArr);
+        }
+      }
+
+      // and now scan to see if we can resolve the conflicts because the rows are
+      // identical in all fields that the user should be able to select. This is after
+      // the above processing because the
+      // ODKDatabaseImplUtils.enforcePermissionsAndOptimizeConflictProcessing()
+      // function may have eliminated all of the differences in the row (if they were
+      // only impacting the permissions fields).
+      //
       if ( !mHaveResolvedMetadataConflicts ) {
 
         boolean tableSetChanged = false;
@@ -121,6 +250,7 @@ class OdkResolveConflictRowLoader extends AsyncTaskLoader<ArrayList<ResolveRowEn
 
           if ( resolveActionList.noChangesInUserDefinedFieldValues() ) {
             tableSetChanged = true;
+            // all users can resolve taking the server's changes
             // Use privileged user roles since we are taking the server's values
             ODKDatabaseImplUtils.resolveServerConflictTakeServerRowWithId(db,
                 mTableId, rowId, aul.activeUser, aul.locale);
@@ -137,6 +267,10 @@ class OdkResolveConflictRowLoader extends AsyncTaskLoader<ArrayList<ResolveRowEn
           table = new UserTable(baseTable, orderedDefns, adminColArr);
         }
       }
+
+      // at this point, the conflict rows that remain can be resolved either by taking the
+      // server changes or by taking the local changes -- the user has the ability to make
+      // that choice.
 
       // The display name is the table display name, not the form display name...
       ArrayList<KeyValueStoreEntry> entries = ODKDatabaseImplUtils.getTableMetadata(db,

--- a/services_app/src/main/java/org/opendatakit/services/resolve/task/ConflictResolutionListTask.java
+++ b/services_app/src/main/java/org/opendatakit/services/resolve/task/ConflictResolutionListTask.java
@@ -100,10 +100,12 @@ public class ConflictResolutionListTask extends AsyncTask<Void, String, String> 
 
           if (entry != null) {
             if (mTakeLocal) {
+              // this might fail due to lowered user privileges
               ODKDatabaseImplUtils
                   .resolveServerConflictTakeLocalRowWithId(db, mTableId, entry.rowId,
                       aul.activeUser, aul.rolesList, aul.locale);
             } else {
+              // all users can always take the server's changes
               ODKDatabaseImplUtils
                   .resolveServerConflictTakeServerRowWithId(db, mTableId, entry.rowId,
                       aul.activeUser, aul.locale);

--- a/services_app/src/main/res/values/strings.xml
+++ b/services_app/src/main/res/values/strings.xml
@@ -70,9 +70,9 @@
     <string name="conflict_take_all_local_updates">Take Local Version - Reject All Server Changes</string>
     <string name="conflict_take_all_server_updates">Take Server Version - Discard Local Changes</string>
     <string name="silently_resolved_single_conflict">A conflict on an unmodifiable row was
-        silently resolved using the server's changes.</string>
+        silently resolved using the server\'s changes.</string>
     <string name="silently_resolved_conflicts">%1$d conflicts on unmodifiable rows were
-        silently resolved using the server's changes.</string>
+        silently resolved using the server\'s changes.</string>
 
     <string name="conflict_resolving_all">Resolving All Conflicts</string>
     <string name="resolving_row_n_of_m">Resolving row %1$d of %2$d</string>

--- a/services_app/src/main/res/values/strings.xml
+++ b/services_app/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
     <string name="no_items_display_checkpoints">Please wait&#8230;\nSearching for checkpoint rows to resolve.</string>
     <string name="checkpoint_take_all_oldest_or_remove">Discard All Checkpoints</string>
     <string name="checkpoint_take_all_newest">Update All Checkpoints to Incomplete State</string>
-    <string name="silently_resolved_single_checkpoint">a checkpoint on an unmodifiable row was
+    <string name="silently_resolved_single_checkpoint">A checkpoint on an unmodifiable row was
         silently rolled back.</string>
     <string name="silently_resolved_checkpoints">%1$d checkpoints on unmodifiable rows were
         silently rolled back.</string>
@@ -69,6 +69,10 @@
     <string name="no_items_display_conflicts">Please Wait&#8230;\nSearching for conflicting rows to resolve.</string>
     <string name="conflict_take_all_local_updates">Take Local Version - Reject All Server Changes</string>
     <string name="conflict_take_all_server_updates">Take Server Version - Discard Local Changes</string>
+    <string name="silently_resolved_single_conflict">A conflict on an unmodifiable row was
+        silently resolved using the server's changes.</string>
+    <string name="silently_resolved_conflicts">%1$d conflicts on unmodifiable rows were
+        silently resolved using the server's changes.</string>
 
     <string name="conflict_resolving_all">Resolving All Conflicts</string>
     <string name="resolving_row_n_of_m">Resolving row %1$d of %2$d</string>


### PR DESCRIPTION
Reproduction case begins with:

    `grunt adbpush-tables-rowlevelaccessdemo`

Reset app on a server, then sync down to a second device. Note that re-initialization after sync is broken (see other issues - -the UI and workflow have become destabilized). This causes the demo to be broken because the properties.csv and key-value-store is not being properly scanned and reloaded after a sync. 

In any case, verify username with admin privileges on both tablets and open ODK Survey and edit the Weather Conditions table, appending to the labels  either "on tablet 1" or "on tablet 2" for all entries. 

Now sync tablet 2.  Then sync tablet 1.

Tablet 1 will pop open the resolve conflicts screen after the sync completes. Open the show-all-open-apps screen and swipe left to close ODK Services.

Now Open ODK Services and go to Settings / Reset Configuration. 

This resets the user to anonymous.

Now choose resolve conflicts. All the conflicts are now automatically resolved and a toast is displayed saying N conflicts were automatically resolved by taking the server's changes. 

NOTE: there is another issue open for enabling privileged users to resolve the permissions columns if they are in conflict. Currently, if you only change permissions on a record on both devices, these changes silently resolve to the server's settings and the set of permissions changes from the last sync are silently discarded.

