### PR TITLE
Bring back Change default form identifier to an underscore in FormsProvider

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/forms/provider/FormsProvider.java
+++ b/services_app/src/main/java/org/opendatakit/services/forms/provider/FormsProvider.java
@@ -405,7 +405,7 @@ public class FormsProvider extends ContentProvider {
       }
     } else {
       // we have both a tableId and a formId.
-      pf.requiresBlankFormIdPatch = ( pf.formId == null || pf.formId.length() == 0 );
+      pf.requiresBlankFormIdPatch = ( pf.formId == null || pf.formId.equals("_") );
 
       // combine with the filter clause the user supplied.
       if (TextUtils.isEmpty(where)) {


### PR DESCRIPTION
Unclear if this change made it in to the whole reversion thing on the makeSurveyUri side