### PR TITLE
Fix crash on using Tables custom home screen

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/TablesSettingsFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/TablesSettingsFragment.java
@@ -53,8 +53,9 @@ public class TablesSettingsFragment extends PreferenceFragment {
     PreferenceCategory deviceCategory = (PreferenceCategory) findPreference
         (CommonToolProperties.GROUPING_TOOL_TABLES_CATEGORY);
 
-    boolean useHomeScreenAvailable = !adminConfigured ||
-        props.getBooleanProperty(CommonToolProperties.KEY_CHANGE_USE_HOME_SCREEN);
+    Boolean useHomeScreen = props.getBooleanProperty(CommonToolProperties.KEY_CHANGE_USE_HOME_SCREEN);
+    useHomeScreen = (useHomeScreen == null) ? false : useHomeScreen;
+    boolean useHomeScreenAvailable = !adminConfigured || useHomeScreen;
 
     mUseHomeScreenPreference = (CheckBoxPreference) findPreference(CommonToolProperties.KEY_USE_HOME_SCREEN);
     if (props.containsKey(CommonToolProperties.KEY_USE_HOME_SCREEN)) {


### PR DESCRIPTION
Fix crash when Admin password is set and a user tries to click on Tables-specific Settings from the Preferences menu.  