### PR TITLE
Fix checkpoint deletion when user has modify privileges

### DIFF
--- a/services_app/src/androidTest/java/org/opendatakit/utilities/test/AbstractPermissionsTestCase.java
+++ b/services_app/src/androidTest/java/org/opendatakit/utilities/test/AbstractPermissionsTestCase.java
@@ -2112,6 +2112,84 @@ public class AbstractPermissionsTestCase {
     return cases;
   }
 
+  protected ArrayList<AuthParamAndOutcome> buildCheckpointOutcomesListDeleteUnlockedNoAnonCreate() {
+    String tableId = testTableUnlockedNoAnonCreate;
+
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    // anon user can't delete, modify, hidden or read-only entries
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    // If default access is modify - a checkpoint row can be
+    // deleted in an unlocked table
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
+    // matching filter value user can do anything
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    // non-matching filter value user can't delete  modify, hidden or read-only entries
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            otherUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            otherUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    // If default access is modify - a checkpoint row can be
+    // deleted in an unlocked table
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, false));
+    // super-user can do anything
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    // admin user can do anything
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+
+
+    return cases;
+  }
+
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListUpdateUnlockedYesAnonCreate() {
     String tableId = testTableUnlockedYesAnonCreate;
 
@@ -2277,6 +2355,83 @@ public class AbstractPermissionsTestCase {
         adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
     cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
         adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+
+    return cases;
+  }
+
+  protected ArrayList<AuthParamAndOutcome> buildCheckpointOutcomesListDeleteUnlockedYesAnonCreate() {
+    String tableId = testTableUnlockedYesAnonCreate;
+
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    // anon user can't delete modify, hidden or read-only entries
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    // If default access is modify - a checkpoint row can be
+    // deleted in an unlocked table
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
+    // matching filter value user can do anything
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    // non-matching filter value user can't delete modify, hidden or read-only entries
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            otherUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            otherUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    // If default access is modify - a checkpoint row can be
+    // deleted in an unlocked table
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, false));
+    // super-user can do anything
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    // admin user can do anything
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
 
     return cases;
   }
@@ -2450,6 +2605,80 @@ public class AbstractPermissionsTestCase {
     return cases;
   }
 
+  protected ArrayList<AuthParamAndOutcome> buildCheckpointOutcomesListDeleteLockedNoAnonCreate() {
+    String tableId = testTableLockedNoAnonCreate;
+
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    // anon user can only delete new row
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    // matching filter value user can delete a checkpoint row as this
+    // could have been created during modification
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            commonUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    // non-matching filter value user can only delete new row
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            otherUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    // super-user can do anything
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    // admin user can do anything
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+
+    return cases;
+  }
+
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListUpdateLockedYesAnonCreate() {
     String tableId = testTableLockedYesAnonCreate;
 
@@ -2615,6 +2844,80 @@ public class AbstractPermissionsTestCase {
         adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
     cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
         adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+
+    return cases;
+  }
+
+  protected ArrayList<AuthParamAndOutcome> buildCheckpointOutcomesListDeleteLockedYesAnonCreate() {
+    String tableId = testTableLockedYesAnonCreate;
+
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    // anon user can't delete anything other than the new row
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
+    // matching filter value user can delete a checkpoint row
+    // that could have been created due to a modification
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            commonUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            commonUser, RoleConsts.USER_ROLES_LIST, false));
+    // non-matching filter value user can't delete anything other than the new row
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            otherUser, RoleConsts.USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            otherUser, RoleConsts.USER_ROLES_LIST, true));
+    // super-user can do anything
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            superUser, RoleConsts.SUPER_USER_ROLES_LIST, false));
+    // admin user can do anything
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommonNew,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdFullCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdHiddenCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdReadOnlyCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
+    cases.add(new AuthParamAndOutcome(tableId, rowIdModifyCommon,
+            adminUser, RoleConsts.ADMIN_ROLES_LIST, false));
 
     return cases;
   }

--- a/services_app/src/androidTest/java/org/opendatakit/utilities/test/ODKDatabaseUtilsDeletePermissionsTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/utilities/test/ODKDatabaseUtilsDeletePermissionsTest.java
@@ -500,8 +500,8 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableUnlockedNoAnonCreate,
         false, false, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteUnlockedNoAnonCreate();
-
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteUnlockedNoAnonCreate();
+    
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
         // expect three row in new_row and two checkpoints in new_row state
@@ -545,7 +545,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableUnlockedYesAnonCreate,
             false, true, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteUnlockedYesAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteUnlockedYesAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
@@ -591,7 +591,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableLockedNoAnonCreate,
             true, false, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteLockedNoAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteLockedNoAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
@@ -637,7 +637,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableLockedYesAnonCreate,
             true, true, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteLockedYesAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteLockedYesAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
@@ -683,7 +683,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableUnlockedNoAnonCreate,
             false, false, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteUnlockedNoAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteUnlockedNoAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
@@ -728,7 +728,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableUnlockedYesAnonCreate,
             false, true, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteUnlockedYesAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteUnlockedYesAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
@@ -774,7 +774,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableLockedNoAnonCreate,
             true, false, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteLockedNoAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteLockedNoAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
@@ -820,7 +820,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableLockedYesAnonCreate,
             true, true, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteLockedYesAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteLockedYesAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
@@ -866,7 +866,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableUnlockedNoAnonCreate,
             false, false, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteUnlockedNoAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteUnlockedNoAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
@@ -911,7 +911,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableUnlockedYesAnonCreate,
             false, true, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteUnlockedYesAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteUnlockedYesAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
@@ -957,7 +957,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableLockedNoAnonCreate,
             true, false, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteLockedNoAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteLockedNoAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
@@ -1003,7 +1003,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableLockedYesAnonCreate,
             true, true, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteLockedYesAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteLockedYesAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( ap.rowId.contains("New") ) {
@@ -1048,7 +1048,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
     OrderedColumns oc = assertEmptyTestTable(testTableUnlockedNoAnonCreate,
             false, false, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteUnlockedNoAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteUnlockedNoAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( !ap.rowId.contains("New") ) {
@@ -1128,7 +1128,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableLockedNoAnonCreate,
             true, false, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteLockedNoAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteLockedNoAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( !ap.rowId.contains("New") ) {
@@ -1168,7 +1168,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         (testTableLockedYesAnonCreate,
             true, true, RowFilterScope.Access.FULL.name());
 
-    ArrayList<AuthParamAndOutcome> cases = buildOutcomesListDeleteLockedYesAnonCreate();
+    ArrayList<AuthParamAndOutcome> cases = buildCheckpointOutcomesListDeleteLockedYesAnonCreate();
 
     for ( AuthParamAndOutcome ap : cases ) {
       if ( !ap.rowId.contains("New") ) {

--- a/services_app/src/main/java/org/opendatakit/services/database/utlities/ODKDatabaseImplUtils.java
+++ b/services_app/src/main/java/org/opendatakit/services/database/utlities/ODKDatabaseImplUtils.java
@@ -58,7 +58,6 @@ import org.opendatakit.provider.SyncETagColumns;
 import org.opendatakit.provider.TableDefinitionsColumns;
 import org.opendatakit.services.database.AndroidConnectFactory;
 import org.opendatakit.services.database.OdkConnectionInterface;
-import org.opendatakit.utilities.DataHelper;
 import org.opendatakit.utilities.LocalizationUtils;
 import org.opendatakit.utilities.ODKFileUtils;
 import org.opendatakit.utilities.StaticStateManipulator;
@@ -3725,7 +3724,7 @@ public class ODKDatabaseImplUtils {
             String priorGroupPrivileged = c.isNull(idxGroupPrivileged) ? null : c.getString(idxGroupPrivileged);
 
             tss.allowRowChange(activeUser, rolesArray, priorSyncState, priorDefaultAccess,
-                priorOwner, priorGroupReadOnly, priorGroupModify, priorGroupPrivileged, RowChange.DELETE_ROW);
+                priorOwner, priorGroupReadOnly, priorGroupModify, priorGroupPrivileged, RowChange.CHANGE_ROW);
           } while (c.moveToNext());
         }
 


### PR DESCRIPTION
The code previously disallowed a user with only modify privileges from deleting a row.  However, when a user creates checkpoint rows, to resolve the checkpoint they also need to be able to delete checkpoint rows.  Users with modify privileges are now allowed to delete a checkpoint row.   