### PR TITLE
fix: always detect changes after sync; visibility and doc changes

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/database/service/OdkDatabaseServiceImpl.java
+++ b/services_app/src/main/java/org/opendatakit/services/database/service/OdkDatabaseServiceImpl.java
@@ -97,7 +97,7 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    * Return the active user or "anonymous" if the user
    * has not been authenticated against the server.
    *
-   * @param appName
+   * @param appName the app name
    *
    * @return the user reported from the server or "anonymous" if
    * server authentication has not been completed.
@@ -116,7 +116,7 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    * or if the server settings specify to use an anonymous user,
    * then return an empty string.
    *
-   * @param appName
+   * @param appName the app name
    *
    * @return empty string or JSON serialization of an array of ROLES. See RoleConsts for possible values.
    */
@@ -141,7 +141,7 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    * the current user. If the user is syncing anonymously with the
    * server, this returns an empty string.
    *
-   * @param appName
+   * @param appName the app name
    *
    * @return null or JSON serialization of an array of objects
    * structured as { "user_id": "...", "full_name": "...", "roles": ["...",...] }
@@ -220,9 +220,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * Create a local only table and prepend the given id with an "L_"
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    * @param columns
    * @return
    */
@@ -253,9 +253,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * Drop the given local only table
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    */
    @Override public void deleteLocalOnlyTable(String appName, DbHandle dbHandleName, String tableId)
        {
@@ -280,9 +280,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * Insert a row into a local only table
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    * @param rowValues
    * @throws ActionNotAuthorizedException
    */
@@ -309,9 +309,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * Update a row in a local only table
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    * @param rowValues
    * @param whereClause
    * @param bindArgs
@@ -344,9 +344,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * Delete a row in a local only table
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    * @param whereClause
    * @param bindArgs
    * @throws ActionNotAuthorizedException
@@ -377,9 +377,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * SYNC Only. ADMIN Privileges
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    * @param schemaETag
    * @param tableInstanceFilesUri
      */
@@ -649,10 +649,10 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * SYNC Only. ADMIN Privileges!
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
-   * @param rowId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
+   * @param rowId which row in the table to update
    * @return
      */
    @Override public BaseTable privilegedDeleteRowWithId(String appName, DbHandle dbHandleName,
@@ -1124,11 +1124,11 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    /**
     * SYNC Only. ADMIN Privileges!
     *
-    * @param appName
-    * @param dbHandleName
-    * @param tableId
+    * @param appName the app name
+    * @param dbHandleName a database handle to use
+    * @param tableId the table to update
     * @param cvValues
-    * @param rowId
+    * @param rowId which row in the table to update
     * @param asCsvRequestedChange
     * @return
     */
@@ -1169,13 +1169,13 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    /**
     * SYNC Only. ADMIN Privileges!
     *
-    * @param appName
-    * @param dbHandleName
-    * @param tableId
+    * @param appName the app name
+    * @param dbHandleName a database handle to use
+    * @param tableId the table to update
     * @param cvValues  server's field values for this row
-    * @param rowId
+    * @param rowId which row in the table to update
     *          expected to be one of ConflictType.LOCAL_DELETED_OLD_VALUES (0) or
-    * @return
+    * @return The updated row, in a table
     */
    @Override public BaseTable privilegedPerhapsPlaceRowIntoConflictWithId(String appName,
        DbHandle dbHandleName, String tableId, ContentValues cvValues,
@@ -1427,11 +1427,11 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    /**
     * SYNC Only. ADMIN Privileges
     *
-    * @param appName
-    * @param dbHandleName
-    * @param tableId
-    * @param schemaETag
-    * @param lastDataETag
+    * @param appName the app name
+    * @param dbHandleName a database handle to use
+    * @param tableId the table to update
+    * @param schemaETag TODO what?
+    * @param lastDataETag TODO what?
     */
    @Override public void privilegedUpdateTableETags(String appName, DbHandle dbHandleName,
        String tableId, String schemaETag, String lastDataETag)
@@ -1458,9 +1458,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    /**
     * SYNC Only. ADMIN Privileges
     *
-    * @param appName
-    * @param dbHandleName
-    * @param tableId
+    * @param appName the app name
+    * @param dbHandleName a database handle to use
+    * @param tableId the table to update
     */
    @Override public void privilegedUpdateTableLastSyncTime(String appName, DbHandle dbHandleName,
        String tableId) {
@@ -1633,11 +1633,11 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    /**
     * SYNC Only. ADMIN Privileges!
     *
-    * @param appName
-    * @param dbHandleName
-    * @param tableId
-    * @param rowId
-    * @param rowETag
+    * @param appName the app name
+    * @param dbHandleName a database handle to use
+    * @param tableId the table to update
+    * @param rowId which row in the table to update
+    * @param rowETag The new etag for the row
     * @param syncState - the SyncState.name()
     */
    @Override public void privilegedUpdateRowETagAndSyncState(String appName, DbHandle dbHandleName,

--- a/services_app/src/main/java/org/opendatakit/services/database/utlities/ChoiceListUtils.java
+++ b/services_app/src/main/java/org/opendatakit/services/database/utlities/ChoiceListUtils.java
@@ -34,8 +34,8 @@ public final class ChoiceListUtils {
   }
 
   /**
-   * @param db
-   * @param choiceListId
+   * @param db           a database connection to use
+   * @param choiceListId which row of choices to get from the database
    * @return
    */
   public static String getChoiceList(OdkConnectionInterface db, String choiceListId) {
@@ -87,6 +87,13 @@ public final class ChoiceListUtils {
     }
   }
 
+  /**
+   * Updates the choice just row with the given id to have the new json
+   *
+   * @param db             a database connection to use
+   * @param choiceListId   the id of the row in the choice list table
+   * @param choiceListJSON json representing the new set of choices
+   */
   public void setChoiceList(OdkConnectionInterface db, String choiceListId,
       String choiceListJSON) {
 

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/SyncExecutionContext.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/SyncExecutionContext.java
@@ -131,7 +131,13 @@ public class SyncExecutionContext implements SynchronizerStatus {
   public String getString(int resId) {
     return application.getString(resId);
   }
-  
+
+  public void signalPropertiesChange() {
+
+    PropertiesSingleton props = CommonToolProperties.get(application, appName);
+    props.signalPropertiesChange();
+  }
+
   public void setAppLevelSyncOutcome(SyncOutcome syncOutcome) {
     mUserResult.setAppLevelSyncOutcome(syncOutcome);
   }

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessAppAndTableLevelChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessAppAndTableLevelChanges.java
@@ -377,6 +377,9 @@ public class ProcessAppAndTableLevelChanges {
           "[synchronizeConfigurationAndContent] exception while trying to synchronize app-level files.");
       sc.setAppLevelSyncOutcome(sc.exceptionEquivalentOutcome(e));
       return new ArrayList<TableResource>();
+    } finally {
+      // because the properties files may have changed, signal that they have
+      sc.signalPropertiesChange();
     }
 
     // done with app-level file synchronization

--- a/services_app/src/main/java/org/sqlite/database/sqlite/SQLiteMemoryCursor.java
+++ b/services_app/src/main/java/org/sqlite/database/sqlite/SQLiteMemoryCursor.java
@@ -37,12 +37,12 @@ public class SQLiteMemoryCursor implements Cursor {
 
   private static final String TAG = "SQLiteMemoryCursor";
   
-    private static final char NULL_TYPE = 'n';
-    private static final char STRING_TYPE = 's';
-    private static final char LONG_TYPE = 'l';
-    private static final char DOUBLE_TYPE = 'd';
-    private static final char BYTEARRAY_TYPE = 'b';
-    private static final char OBJECT_TYPE = 'o';
+    static final char NULL_TYPE = 'n';
+    static final char STRING_TYPE = 's';
+    static final char LONG_TYPE = 'l';
+    static final char DOUBLE_TYPE = 'd';
+    static final char BYTEARRAY_TYPE = 'b';
+    static final char OBJECT_TYPE = 'o';
     private static final String[] NO_COLUMNS = new String[0];
 
     private Object[] sqliteContent;


### PR DESCRIPTION
(1) add call to signalPropertiesChange() after sync'ing of app-level files. This ensures that clients will detect changes in those files. Dependent upon #https://github.com/opendatakit/androidlibrary/pull/26
(2) Documentation updates and a change to package-visibility for some static field values.