### PR TITLE
remove return values for insert and replace APIs; add factory.

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/database/OdkConnectionInterface.java
+++ b/services_app/src/main/java/org/opendatakit/services/database/OdkConnectionInterface.java
@@ -123,10 +123,10 @@ public interface OdkConnectionInterface {
 
     int delete(String table, String whereClause, Object[] whereArgs) throws SQLException;
 
-    long replaceOrThrow(String table, String nullColumnHack, Map<String,Object> initialValues)
+    void replaceOrThrow(String table, String nullColumnHack, Map<String,Object> initialValues)
             throws SQLException;
 
-    long insertOrThrow(String table, String nullColumnHack, Map<String,Object> values)
+    void insertOrThrow(String table, String nullColumnHack, Map<String,Object> values)
             throws SQLException;
 
     void execSQL(String sql, Object[] bindArgs) throws SQLException;

--- a/services_app/src/main/java/org/opendatakit/services/database/SQLConnectionFactory.java
+++ b/services_app/src/main/java/org/opendatakit/services/database/SQLConnectionFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 University of Washington
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.services.database;
+
+import org.sqlite.database.DatabaseErrorHandler;
+import org.sqlite.database.sqlite.SQLiteConnection;
+import org.sqlite.database.sqlite.SQLiteConnectionBase;
+import org.sqlite.database.sqlite.SQLiteDatabaseConfiguration;
+
+/**
+ * Factory class to enable swapping out of SQLite database implementation
+ * for, e.g., desktop operation.
+ */
+public class SQLConnectionFactory {
+
+  private SQLConnectionFactory() {};
+
+  public static final SQLiteConnectionBase get(SQLiteDatabaseConfiguration configuration,
+                                           OperationLog recentOperations,
+                                           DatabaseErrorHandler errorHandler,
+                                           String sessionQualifier) {
+    return new SQLiteConnection(configuration, recentOperations, errorHandler,
+        sessionQualifier);
+
+  }
+}

--- a/services_app/src/main/java/org/opendatakit/services/database/service/OdkDatabaseServiceImpl.java
+++ b/services_app/src/main/java/org/opendatakit/services/database/service/OdkDatabaseServiceImpl.java
@@ -97,7 +97,7 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    * Return the active user or "anonymous" if the user
    * has not been authenticated against the server.
    *
-   * @param appName
+   * @param appName the app name
    *
    * @return the user reported from the server or "anonymous" if
    * server authentication has not been completed.
@@ -116,7 +116,7 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    * or if the server settings specify to use an anonymous user,
    * then return an empty string.
    *
-   * @param appName
+   * @param appName the app name
    *
    * @return empty string or JSON serialization of an array of ROLES. See RoleConsts for possible values.
    */
@@ -141,7 +141,7 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    * the current user. If the user is syncing anonymously with the
    * server, this returns an empty string.
    *
-   * @param appName
+   * @param appName the app name
    *
    * @return null or JSON serialization of an array of objects
    * structured as { "user_id": "...", "full_name": "...", "roles": ["...",...] }
@@ -220,9 +220,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * Create a local only table and prepend the given id with an "L_"
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    * @param columns
    * @return
    */
@@ -253,9 +253,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * Drop the given local only table
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    */
    @Override public void deleteLocalOnlyTable(String appName, DbHandle dbHandleName, String tableId)
        {
@@ -280,9 +280,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * Insert a row into a local only table
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    * @param rowValues
    * @throws ActionNotAuthorizedException
    */
@@ -309,9 +309,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * Update a row in a local only table
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    * @param rowValues
    * @param whereClause
    * @param bindArgs
@@ -344,9 +344,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * Delete a row in a local only table
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    * @param whereClause
    * @param bindArgs
    * @throws ActionNotAuthorizedException
@@ -377,9 +377,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * SYNC Only. ADMIN Privileges
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
    * @param schemaETag
    * @param tableInstanceFilesUri
      */
@@ -649,10 +649,10 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
   /**
    * SYNC Only. ADMIN Privileges!
    *
-   * @param appName
-   * @param dbHandleName
-   * @param tableId
-   * @param rowId
+   * @param appName the app name
+   * @param dbHandleName a database handle to use
+   * @param tableId the table to update
+   * @param rowId which row in the table to update
    * @return
      */
    @Override public BaseTable privilegedDeleteRowWithId(String appName, DbHandle dbHandleName,
@@ -1124,11 +1124,11 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    /**
     * SYNC Only. ADMIN Privileges!
     *
-    * @param appName
-    * @param dbHandleName
-    * @param tableId
+    * @param appName the app name
+    * @param dbHandleName a database handle to use
+    * @param tableId the table to update
     * @param cvValues
-    * @param rowId
+    * @param rowId which row in the table to update
     * @param asCsvRequestedChange
     * @return
     */
@@ -1169,13 +1169,13 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    /**
     * SYNC Only. ADMIN Privileges!
     *
-    * @param appName
-    * @param dbHandleName
-    * @param tableId
+    * @param appName the app name
+    * @param dbHandleName a database handle to use
+    * @param tableId the table to update
     * @param cvValues  server's field values for this row
-    * @param rowId
+    * @param rowId which row in the table to update
     *          expected to be one of ConflictType.LOCAL_DELETED_OLD_VALUES (0) or
-    * @return
+    * @return The updated row, in a table
     */
    @Override public BaseTable privilegedPerhapsPlaceRowIntoConflictWithId(String appName,
        DbHandle dbHandleName, String tableId, ContentValues cvValues,
@@ -1427,11 +1427,11 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    /**
     * SYNC Only. ADMIN Privileges
     *
-    * @param appName
-    * @param dbHandleName
-    * @param tableId
-    * @param schemaETag
-    * @param lastDataETag
+    * @param appName the app name
+    * @param dbHandleName a database handle to use
+    * @param tableId the table to update
+    * @param schemaETag TODO what?
+    * @param lastDataETag TODO what?
     */
    @Override public void privilegedUpdateTableETags(String appName, DbHandle dbHandleName,
        String tableId, String schemaETag, String lastDataETag)
@@ -1458,9 +1458,9 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    /**
     * SYNC Only. ADMIN Privileges
     *
-    * @param appName
-    * @param dbHandleName
-    * @param tableId
+    * @param appName the app name
+    * @param dbHandleName a database handle to use
+    * @param tableId the table to update
     */
    @Override public void privilegedUpdateTableLastSyncTime(String appName, DbHandle dbHandleName,
        String tableId) {
@@ -1633,11 +1633,11 @@ public final class OdkDatabaseServiceImpl implements InternalUserDbInterface {
    /**
     * SYNC Only. ADMIN Privileges!
     *
-    * @param appName
-    * @param dbHandleName
-    * @param tableId
-    * @param rowId
-    * @param rowETag
+    * @param appName the app name
+    * @param dbHandleName a database handle to use
+    * @param tableId the table to update
+    * @param rowId which row in the table to update
+    * @param rowETag The new etag for the row
     * @param syncState - the SyncState.name()
     */
    @Override public void privilegedUpdateRowETagAndSyncState(String appName, DbHandle dbHandleName,

--- a/services_app/src/main/java/org/opendatakit/services/database/utlities/ChoiceListUtils.java
+++ b/services_app/src/main/java/org/opendatakit/services/database/utlities/ChoiceListUtils.java
@@ -34,8 +34,8 @@ public final class ChoiceListUtils {
   }
 
   /**
-   * @param db
-   * @param choiceListId
+   * @param db           a database connection to use
+   * @param choiceListId which row of choices to get from the database
    * @return
    */
   public static String getChoiceList(OdkConnectionInterface db, String choiceListId) {
@@ -87,6 +87,13 @@ public final class ChoiceListUtils {
     }
   }
 
+  /**
+   * Updates the choice just row with the given id to have the new json
+   *
+   * @param db             a database connection to use
+   * @param choiceListId   the id of the row in the choice list table
+   * @param choiceListJSON json representing the new set of choices
+   */
   public void setChoiceList(OdkConnectionInterface db, String choiceListId,
       String choiceListJSON) {
 

--- a/services_app/src/main/java/org/opendatakit/services/forms/provider/FormsProvider.java
+++ b/services_app/src/main/java/org/opendatakit/services/forms/provider/FormsProvider.java
@@ -241,18 +241,14 @@ public class FormsProvider extends ContentProvider {
       }
 
       try {
-        long rowId = db.insertOrThrow(DatabaseConstants.FORMS_TABLE_NAME, null, values);
+        db.insertOrThrow(DatabaseConstants.FORMS_TABLE_NAME, null, values);
         db.setTransactionSuccessful();
         // and notify listeners of the new row...
         Uri formUri = Uri.withAppendedPath(
             Uri.withAppendedPath(Uri.parse("content://" + getFormsAuthority()), appName),
             (String) values.get(FormsColumns.FORM_ID));
-        Uri idUri = Uri.withAppendedPath(
-            Uri.withAppendedPath(Uri.parse("content://" + getFormsAuthority()), appName),
-            Long.toString(rowId));
         if (getContext() != null) {
           getContext().getContentResolver().notifyChange(formUri, null);
-          getContext().getContentResolver().notifyChange(idUri, null);
         }
         return formUri;
       } catch (Exception e) {

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/SyncExecutionContext.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/SyncExecutionContext.java
@@ -131,7 +131,13 @@ public class SyncExecutionContext implements SynchronizerStatus {
   public String getString(int resId) {
     return application.getString(resId);
   }
-  
+
+  public void signalPropertiesChange() {
+
+    PropertiesSingleton props = CommonToolProperties.get(application, appName);
+    props.signalPropertiesChange();
+  }
+
   public void setAppLevelSyncOutcome(SyncOutcome syncOutcome) {
     mUserResult.setAppLevelSyncOutcome(syncOutcome);
   }

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessAppAndTableLevelChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessAppAndTableLevelChanges.java
@@ -377,6 +377,9 @@ public class ProcessAppAndTableLevelChanges {
           "[synchronizeConfigurationAndContent] exception while trying to synchronize app-level files.");
       sc.setAppLevelSyncOutcome(sc.exceptionEquivalentOutcome(e));
       return new ArrayList<TableResource>();
+    } finally {
+      // because the properties files may have changed, signal that they have
+      sc.signalPropertiesChange();
     }
 
     // done with app-level file synchronization

--- a/services_app/src/main/java/org/sqlite/database/DatabaseErrorHandler.java
+++ b/services_app/src/main/java/org/sqlite/database/DatabaseErrorHandler.java
@@ -20,7 +20,7 @@
 
 package org.sqlite.database;
 
-import org.sqlite.database.sqlite.SQLiteConnection;
+import org.sqlite.database.sqlite.SQLiteConnectionBase;
 
 /**
  * An interface to let the apps define the actions to take when the following errors are detected
@@ -30,8 +30,8 @@ public interface DatabaseErrorHandler {
 
     /**
      * defines the method to be invoked when database corruption is detected.
-     * @param dbConnection the {@link SQLiteConnection} object representing
+     * @param dbConnection the {@link SQLiteConnectionBase} object representing
      *                the database connection on which corruption is detected.
      */
-    void onCorruption(SQLiteConnection dbConnection);
+    void onCorruption(SQLiteConnectionBase dbConnection);
 }

--- a/services_app/src/main/java/org/sqlite/database/DefaultDatabaseErrorHandler.java
+++ b/services_app/src/main/java/org/sqlite/database/DefaultDatabaseErrorHandler.java
@@ -20,20 +20,15 @@
 
 package org.sqlite.database;
 
-import org.opendatakit.services.database.OperationLog;
-import org.sqlite.database.sqlite.SQLiteConnection;
-import org.sqlite.database.sqlite.SQLiteDatabaseConfiguration;
+import org.sqlite.database.sqlite.SQLiteConnectionBase;
 
 /**
  * Default class used to define the actions to take when the database corruption is reported
  * by sqlite.  This had destroyed the database. Changed to simply report the error.
  * <p>
  * An application can specify an implementation of {@link DatabaseErrorHandler} on the
- * following:
- * <ul>
- *   <li>{@link SQLiteConnection#SQLiteConnection(SQLiteDatabaseConfiguration,
- *         OperationLog, DatabaseErrorHandler, String)}</li>
- * </ul>
+ * constructor of the class derived from {@link }SQLiteConnectionBase}.
+ *
  * The specified {@link DatabaseErrorHandler} is used to handle database corruption errors, if they
  * occur.
  * <p>
@@ -46,10 +41,10 @@ public final class DefaultDatabaseErrorHandler implements DatabaseErrorHandler {
 
     /**
      * defines the default method to be invoked when database corruption is detected.
-     * @param dbConnection the {@link SQLiteConnection} object representing the database
+     * @param dbConnection the {@link SQLiteConnectionBase} object representing the database
      *                     connection on which corruption is detected.
      */
-    public void onCorruption(SQLiteConnection dbConnection) {
+    public void onCorruption(SQLiteConnectionBase dbConnection) {
        dbConnection.getLogger().e(TAG, "Corruption reported by sqlite on database: "
            + dbConnection.getAppName());
        throw new IllegalStateException("Corrupted database -- what do we do now?");

--- a/services_app/src/main/java/org/sqlite/database/sqlite/SQLiteConnection.java
+++ b/services_app/src/main/java/org/sqlite/database/sqlite/SQLiteConnection.java
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 /*
-** Modified to support SQLite extensions by the SQLite developers: 
+** Modified to support SQLite extensions by the SQLite developers:
 ** sqlite-dev@sqlite.org.
 */
 
@@ -27,13 +27,11 @@ package org.sqlite.database.sqlite;
 import android.database.Cursor;
 import android.os.CancellationSignal;
 import android.os.OperationCanceledException;
-
 import org.opendatakit.logging.WebLogger;
 import org.opendatakit.logging.WebLoggerIf;
 import org.opendatakit.services.database.AppNameSharedStateContainer;
 import org.opendatakit.services.database.OperationLog;
 import org.opendatakit.utilities.ODKFileUtils;
-
 import org.sqlite.database.DatabaseErrorHandler;
 import org.sqlite.database.DefaultDatabaseErrorHandler;
 import org.sqlite.database.SQLException;
@@ -89,7 +87,8 @@ import java.util.regex.Pattern;
  *
  * @hide
  */
-public final class SQLiteConnection extends SQLiteClosable implements CancellationSignal.OnCancelListener {
+public final class SQLiteConnection extends SQLiteConnectionBase implements CancellationSignal
+    .OnCancelListener {
    private static final String TAG = "SQLiteConnection";
    private static final boolean DEBUG = false;
 
@@ -149,165 +148,9 @@ public final class SQLiteConnection extends SQLiteClosable implements Cancellati
    }
 
 
-   /**
-    * Transaction mode: Deferred.
-    * <p>
-    * In a deferred transaction, no locks are acquired on the database
-    * until the first operation is performed.  If the first operation is
-    * read-only, then a <code>SHARED</code> lock is acquired, otherwise
-    * a <code>RESERVED</code> lock is acquired.
-    * </p><p>
-    * While holding a <code>SHARED</code> lock, this session is only allowed to
-    * read but other sessions are allowed to read or write.
-    * While holding a <code>RESERVED</code> lock, this session is allowed to read
-    * or write but other sessions are only allowed to read.
-    * </p><p>
-    * Because the lock is only acquired when needed in a deferred transaction,
-    * it is possible for another session to write to the database first before
-    * this session has a chance to do anything.
-    * </p><p>
-    * Corresponds to the SQLite <code>BEGIN DEFERRED</code> transaction mode.
-    * </p>
-    */
-   public static final int TRANSACTION_MODE_DEFERRED = 0;
-
-   /**
-    * Transaction mode: Immediate.
-    * <p>
-    * When an immediate transaction begins, the session acquires a
-    * <code>RESERVED</code> lock.
-    * </p><p>
-    * While holding a <code>RESERVED</code> lock, this session is allowed to read
-    * or write but other sessions are only allowed to read.
-    * </p><p>
-    * Corresponds to the SQLite <code>BEGIN IMMEDIATE</code> transaction mode.
-    * </p>
-    */
-   public static final int TRANSACTION_MODE_IMMEDIATE = 1;
-
-   /**
-    * Transaction mode: Exclusive.
-    * <p>
-    * When an exclusive transaction begins, the session acquires an
-    * <code>EXCLUSIVE</code> lock.
-    * </p><p>
-    * While holding an <code>EXCLUSIVE</code> lock, this session is allowed to read
-    * or write but no other sessions are allowed to access the database.
-    * </p><p>
-    * Corresponds to the SQLite <code>BEGIN EXCLUSIVE</code> transaction mode.
-    * </p>
-    */
-   public static final int TRANSACTION_MODE_EXCLUSIVE = 2;
-
-   /**
-    * When a constraint violation occurs, an immediate ROLLBACK occurs,
-    * thus ending the current transaction, and the command aborts with a
-    * return code of SQLITE_CONSTRAINT. If no transaction is active
-    * (other than the implied transaction that is created on every command)
-    * then this algorithm works the same as ABORT.
-    */
-   public static final int CONFLICT_ROLLBACK = 1;
-
-   /**
-    * When a constraint violation occurs,no ROLLBACK is executed
-    * so changes from prior commands within the same transaction
-    * are preserved. This is the default behavior.
-    */
-   public static final int CONFLICT_ABORT = 2;
-
-   /**
-    * When a constraint violation occurs, the command aborts with a return
-    * code SQLITE_CONSTRAINT. But any changes to the database that
-    * the command made prior to encountering the constraint violation
-    * are preserved and are not backed out.
-    */
-   public static final int CONFLICT_FAIL = 3;
-
-   /**
-    * When a constraint violation occurs, the one row that contains
-    * the constraint violation is not inserted or changed.
-    * But the command continues executing normally. Other rows before and
-    * after the row that contained the constraint violation continue to be
-    * inserted or updated normally. No error is returned.
-    */
-   public static final int CONFLICT_IGNORE = 4;
-
-   /**
-    * When a UNIQUE constraint violation occurs, the pre-existing rows that
-    * are causing the constraint violation are removed prior to inserting
-    * or updating the current row. Thus the insert or update always occurs.
-    * The command continues executing normally. No error is returned.
-    * If a NOT NULL constraint violation occurs, the NULL value is replaced
-    * by the default value for that column. If the column has no default
-    * value, then the ABORT algorithm is used. If a CHECK constraint
-    * violation occurs then the IGNORE algorithm is used. When this conflict
-    * resolution strategy deletes rows in order to satisfy a constraint,
-    * it does not invoke delete triggers on those rows.
-    * This behavior might change in a future release.
-    */
-   public static final int CONFLICT_REPLACE = 5;
-
-   /**
-    * Use the following when no conflict action is specified.
-    */
-   public static final int CONFLICT_NONE = 0;
-
    private static final String[] CONFLICT_VALUES = new String[]
        {"", " OR ROLLBACK ", " OR ABORT ", " OR FAIL ", " OR IGNORE ", " OR REPLACE "};
 
-   /**
-    * Maximum Length Of A LIKE Or GLOB Pattern
-    * The pattern matching algorithm used in the default LIKE and GLOB implementation
-    * of SQLite can exhibit O(N^2) performance (where N is the number of characters in
-    * the pattern) for certain pathological cases. To avoid denial-of-service attacks
-    * the length of the LIKE or GLOB pattern is limited to SQLITE_MAX_LIKE_PATTERN_LENGTH bytes.
-    * The default value of this limit is 50000. A modern workstation can evaluate
-    * even a pathological LIKE or GLOB pattern of 50000 bytes relatively quickly.
-    * The denial of service problem only comes into play when the pattern length gets
-    * into millions of bytes. Nevertheless, since most useful LIKE or GLOB patterns
-    * are at most a few dozen bytes in length, paranoid application developers may
-    * want to reduce this parameter to something in the range of a few hundred
-    * if they know that external users are able to generate arbitrary patterns.
-    */
-   public static final int SQLITE_MAX_LIKE_PATTERN_LENGTH = 50000;
-
-   /**
-    * Open flag: Flag for {@link SQLiteDatabaseConfiguration} to open the database for reading and writing.
-    * If the disk is full, this may fail even before you actually write anything.
-    *
-    * {@more} Note that the value of this flag is 0, so it is the default.
-    */
-   public static final int OPEN_READWRITE = 0x00000000;          // update native code if changing
-
-   /**
-    * Open flag: Flag for {@link #openDatabase} to open the database for reading only.
-    * This is the only reliable way to open a database if the disk may be full.
-    */
-   // public static final int OPEN_READONLY = 0x00000001;           // update native code if changing
-
-   // private static final int OPEN_READ_MASK = 0x00000001;         // update native code if changing
-
-   /**
-    * Open flag: Flag for {@link SQLiteDatabaseConfiguration} to open the database without support for
-    * localized collators.
-    *
-    * {@more} This causes the collator <code>LOCALIZED</code> not to be created.
-    * You must be consistent when using this flag to use the setting the database was
-    * created with.  If this is set, setLocale will do nothing.
-    */
-   public static final int NO_LOCALIZED_COLLATORS = 0x00000010;  // update native code if changing
-
-   /**
-    * Open flag: Flag for {@link SQLiteDatabaseConfiguration} to create the database file if it does not
-    * already exist.
-    */
-   public static final int CREATE_IF_NECESSARY = 0x10000000;     // update native code if changing
-
-   /**
-    * Open flag: Flag for {@link SQLiteDatabaseConfiguration} to open the database file with
-    * write-ahead logging enabled by default.
-    */
-   public static final int ENABLE_WRITE_AHEAD_LOGGING = 0x20000000;
 
    /**
     * Pattern used to extract the limit condition from a query.
@@ -1194,11 +1037,10 @@ public final class SQLiteConnection extends SQLiteClosable implements Cancellati
     *            row. The keys should be the column names and the values the
     *            column values
     * @throws SQLException
-    * @return the row ID of the newly inserted row, or -1 if an error occurred
     */
-   public long insertOrThrow(String table, String nullColumnHack, Map<String,Object> values)
+   public void insertOrThrow(String table, String nullColumnHack, Map<String,Object> values)
        throws SQLException {
-      return insertWithOnConflict(table, nullColumnHack, values, CONFLICT_NONE);
+      insertWithOnConflict(table, nullColumnHack, values, CONFLICT_NONE);
    }
 
    /**
@@ -1215,11 +1057,10 @@ public final class SQLiteConnection extends SQLiteClosable implements Cancellati
     * @param initialValues this map contains the initial column values for
     *   the row. The key
     * @throws SQLException
-    * @return the row ID of the newly inserted row, or -1 if an error occurred
     */
-   public long replaceOrThrow(String table, String nullColumnHack,
-       Map<String,Object> initialValues) throws SQLException {
-      return insertWithOnConflict(table, nullColumnHack, initialValues, CONFLICT_REPLACE);
+   public void replaceOrThrow(String table, String nullColumnHack,
+                              Map<String,Object> initialValues) throws SQLException {
+      insertWithOnConflict(table, nullColumnHack, initialValues, CONFLICT_REPLACE);
    }
 
    /**

--- a/services_app/src/main/java/org/sqlite/database/sqlite/SQLiteConnectionBase.java
+++ b/services_app/src/main/java/org/sqlite/database/sqlite/SQLiteConnectionBase.java
@@ -1,0 +1,215 @@
+package org.sqlite.database.sqlite;
+
+import android.database.Cursor;
+import android.os.CancellationSignal;
+import org.opendatakit.logging.WebLoggerIf;
+import org.sqlite.database.SQLException;
+
+import java.util.Map;
+
+public abstract class SQLiteConnectionBase extends SQLiteClosable {
+
+
+   /**
+    * Transaction mode: Deferred.
+    * <p>
+    * In a deferred transaction, no locks are acquired on the database
+    * until the first operation is performed.  If the first operation is
+    * read-only, then a <code>SHARED</code> lock is acquired, otherwise
+    * a <code>RESERVED</code> lock is acquired.
+    * </p><p>
+    * While holding a <code>SHARED</code> lock, this session is only allowed to
+    * read but other sessions are allowed to read or write.
+    * While holding a <code>RESERVED</code> lock, this session is allowed to read
+    * or write but other sessions are only allowed to read.
+    * </p><p>
+    * Because the lock is only acquired when needed in a deferred transaction,
+    * it is possible for another session to write to the database first before
+    * this session has a chance to do anything.
+    * </p><p>
+    * Corresponds to the SQLite <code>BEGIN DEFERRED</code> transaction mode.
+    * </p>
+    */
+   public static final int TRANSACTION_MODE_DEFERRED = 0;
+
+   /**
+    * Transaction mode: Immediate.
+    * <p>
+    * When an immediate transaction begins, the session acquires a
+    * <code>RESERVED</code> lock.
+    * </p><p>
+    * While holding a <code>RESERVED</code> lock, this session is allowed to read
+    * or write but other sessions are only allowed to read.
+    * </p><p>
+    * Corresponds to the SQLite <code>BEGIN IMMEDIATE</code> transaction mode.
+    * </p>
+    */
+   public static final int TRANSACTION_MODE_IMMEDIATE = 1;
+
+   /**
+    * Transaction mode: Exclusive.
+    * <p>
+    * When an exclusive transaction begins, the session acquires an
+    * <code>EXCLUSIVE</code> lock.
+    * </p><p>
+    * While holding an <code>EXCLUSIVE</code> lock, this session is allowed to read
+    * or write but no other sessions are allowed to access the database.
+    * </p><p>
+    * Corresponds to the SQLite <code>BEGIN EXCLUSIVE</code> transaction mode.
+    * </p>
+    */
+   public static final int TRANSACTION_MODE_EXCLUSIVE = 2;
+
+   /**
+    * When a constraint violation occurs, an immediate ROLLBACK occurs,
+    * thus ending the current transaction, and the command aborts with a
+    * return code of SQLITE_CONSTRAINT. If no transaction is active
+    * (other than the implied transaction that is created on every command)
+    * then this algorithm works the same as ABORT.
+    */
+   public static final int CONFLICT_ROLLBACK = 1;
+
+   /**
+    * When a constraint violation occurs,no ROLLBACK is executed
+    * so changes from prior commands within the same transaction
+    * are preserved. This is the default behavior.
+    */
+   public static final int CONFLICT_ABORT = 2;
+
+   /**
+    * When a constraint violation occurs, the command aborts with a return
+    * code SQLITE_CONSTRAINT. But any changes to the database that
+    * the command made prior to encountering the constraint violation
+    * are preserved and are not backed out.
+    */
+   public static final int CONFLICT_FAIL = 3;
+
+   /**
+    * When a constraint violation occurs, the one row that contains
+    * the constraint violation is not inserted or changed.
+    * But the command continues executing normally. Other rows before and
+    * after the row that contained the constraint violation continue to be
+    * inserted or updated normally. No error is returned.
+    */
+   public static final int CONFLICT_IGNORE = 4;
+
+   /**
+    * When a UNIQUE constraint violation occurs, the pre-existing rows that
+    * are causing the constraint violation are removed prior to inserting
+    * or updating the current row. Thus the insert or update always occurs.
+    * The command continues executing normally. No error is returned.
+    * If a NOT NULL constraint violation occurs, the NULL value is replaced
+    * by the default value for that column. If the column has no default
+    * value, then the ABORT algorithm is used. If a CHECK constraint
+    * violation occurs then the IGNORE algorithm is used. When this conflict
+    * resolution strategy deletes rows in order to satisfy a constraint,
+    * it does not invoke delete triggers on those rows.
+    * This behavior might change in a future release.
+    */
+   public static final int CONFLICT_REPLACE = 5;
+
+   /**
+    * Use the following when no conflict action is specified.
+    */
+   public static final int CONFLICT_NONE = 0;
+
+   /**
+    * Maximum Length Of A LIKE Or GLOB Pattern
+    * The pattern matching algorithm used in the default LIKE and GLOB implementation
+    * of SQLite can exhibit O(N^2) performance (where N is the number of characters in
+    * the pattern) for certain pathological cases. To avoid denial-of-service attacks
+    * the length of the LIKE or GLOB pattern is limited to SQLITE_MAX_LIKE_PATTERN_LENGTH bytes.
+    * The default value of this limit is 50000. A modern workstation can evaluate
+    * even a pathological LIKE or GLOB pattern of 50000 bytes relatively quickly.
+    * The denial of service problem only comes into play when the pattern length gets
+    * into millions of bytes. Nevertheless, since most useful LIKE or GLOB patterns
+    * are at most a few dozen bytes in length, paranoid application developers may
+    * want to reduce this parameter to something in the range of a few hundred
+    * if they know that external users are able to generate arbitrary patterns.
+    */
+   public static final int SQLITE_MAX_LIKE_PATTERN_LENGTH = 50000;
+
+   /**
+    * Open flag: Flag for {@link SQLiteDatabaseConfiguration} to open the database for reading and writing.
+    * If the disk is full, this may fail even before you actually write anything.
+    *
+    * {@more} Note that the value of this flag is 0, so it is the default.
+    */
+   public static final int OPEN_READWRITE = 0x00000000;          // update native code if changing
+
+   /**
+    * Open flag: Flag for {@link #openDatabase} to open the database for reading only.
+    * This is the only reliable way to open a database if the disk may be full.
+    */
+   // public static final int OPEN_READONLY = 0x00000001;           // update native code if changing
+
+   // private static final int OPEN_READ_MASK = 0x00000001;         // update native code if changing
+
+   /**
+    * Open flag: Flag for {@link SQLiteDatabaseConfiguration} to open the database without support for
+    * localized collators.
+    *
+    * {@more} This causes the collator <code>LOCALIZED</code> not to be created.
+    * You must be consistent when using this flag to use the setting the database was
+    * created with.  If this is set, setLocale will do nothing.
+    */
+   public static final int NO_LOCALIZED_COLLATORS = 0x00000010;  // update native code if changing
+
+   /**
+    * Open flag: Flag for {@link SQLiteDatabaseConfiguration} to create the database file if it does not
+    * already exist.
+    */
+   public static final int CREATE_IF_NECESSARY = 0x10000000;     // update native code if changing
+
+   /**
+    * Open flag: Flag for {@link SQLiteDatabaseConfiguration} to open the database file with
+    * write-ahead logging enabled by default.
+    */
+   public static final int ENABLE_WRITE_AHEAD_LOGGING = 0x20000000;
+
+   public abstract String getAppName();
+
+   public abstract WebLoggerIf getLogger();
+
+   public abstract void open();
+
+   public abstract boolean isOpen();
+
+   public abstract int getVersion();
+
+   public abstract void setVersion(int version);
+
+   public abstract void beginTransaction(int transactionMode,
+                                         CancellationSignal cancellationSignal);
+
+   public abstract boolean inTransaction();
+
+   public abstract void setTransactionSuccessful();
+
+   public abstract void endTransaction();
+
+   public abstract int update(String table, Map<String,Object> values, String whereClause, Object[] whereArgs);
+
+   public abstract int delete(String table, String whereClause, Object[] whereArgs);
+
+   public abstract void replaceOrThrow(String table, String nullColumnHack,
+                                       Map<String,Object> initialValues) throws SQLException;
+
+   public abstract void insertOrThrow(String table, String nullColumnHack, Map<String,Object> values)
+       throws SQLException;
+
+   public abstract void execSQL(String sql, Object[] bindArgs) throws SQLException;
+
+   public abstract Cursor rawQuery(String sql, Object[] selectionArgs, CancellationSignal cancellationSignal);
+
+   public abstract Cursor query(String table, String[] columns, String selection,
+                                Object[] selectionArgs, String groupBy, String having,
+                                String orderBy, String limit);
+
+   public abstract Cursor query(boolean distinct, String table, String[] columns,
+                                String selection, Object[] selectionArgs, String groupBy,
+                                String having, String orderBy, String limit, CancellationSignal cancellationSignal);
+
+   public abstract void dump(StringBuilder b, boolean verbose);
+
+}

--- a/services_app/src/main/java/org/sqlite/database/sqlite/SQLiteMemoryCursor.java
+++ b/services_app/src/main/java/org/sqlite/database/sqlite/SQLiteMemoryCursor.java
@@ -37,12 +37,12 @@ public class SQLiteMemoryCursor implements Cursor {
 
   private static final String TAG = "SQLiteMemoryCursor";
   
-    private static final char NULL_TYPE = 'n';
-    private static final char STRING_TYPE = 's';
-    private static final char LONG_TYPE = 'l';
-    private static final char DOUBLE_TYPE = 'd';
-    private static final char BYTEARRAY_TYPE = 'b';
-    private static final char OBJECT_TYPE = 'o';
+    static final char NULL_TYPE = 'n';
+    static final char STRING_TYPE = 's';
+    static final char LONG_TYPE = 'l';
+    static final char DOUBLE_TYPE = 'd';
+    static final char BYTEARRAY_TYPE = 'b';
+    static final char OBJECT_TYPE = 'o';
     private static final String[] NO_COLUMNS = new String[0];
 
     private Object[] sqliteContent;


### PR DESCRIPTION
These are changes needed to maximize code reuse on website:
(1) SQLiteConnection split into SQLiteConnectBase abstract class and the implementation class. 
(2) SQLiteConnectionFactory class added. Creates a new SQLiteConnection.
(3) Remove the return values for insert and replace. These are unused except in the FormsProvider, where the value is used to invalidate any cursors that are open against that newly created row -- which are necessarily none -- so removal of that code has no impact.