### PR TITLE
Fix permission check logic

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/MainActivity.java
+++ b/services_app/src/main/java/org/opendatakit/services/MainActivity.java
@@ -81,7 +81,7 @@ public class MainActivity extends Activity implements IAppAwareActivity,
 
     this.permissionOnly = getIntent().getBooleanExtra(IntentConsts.INTENT_KEY_PERMISSION_ONLY, false);
 
-    if (!RuntimePermissionUtils.checkSelfAnyPermission(this, REQUIRED_PERMISSIONS)) {
+    if (!RuntimePermissionUtils.checkSelfAllPermission(this, REQUIRED_PERMISSIONS)) {
       ActivityCompat.requestPermissions(
           this,
           REQUIRED_PERMISSIONS,


### PR DESCRIPTION
Should verify if all permissions are granted instead of verifying if at least 1 permission is granted. 

Depends on https://github.com/opendatakit/androidlibrary/pull/32