### PR TITLE
Delete form defs from the _formDef table that are associated with table to be deleted

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/database/utlities/ODKDatabaseImplUtils.java
+++ b/services_app/src/main/java/org/opendatakit/services/database/utlities/ODKDatabaseImplUtils.java
@@ -92,6 +92,7 @@ public final class ODKDatabaseImplUtils {
   private static final String K_OFFSET = " OFFSET ";
 
   private static final String K_TABLE_DEFS_TABLE_ID_EQUALS_PARAM = TableDefinitionsColumns.TABLE_ID + S_EQUALS_PARAM;
+  private static final String K_FORM_DEFS_TABLE_ID_EQUALS_PARAM = FormsColumns.TABLE_ID + S_EQUALS_PARAM;
 
   private static final String K_COLUMN_DEFS_TABLE_ID_EQUALS_PARAM = ColumnDefinitionsColumns.TABLE_ID + S_EQUALS_PARAM;
 
@@ -1444,6 +1445,13 @@ public final class ODKDatabaseImplUtils {
         String whereClause = K_TABLE_DEFS_TABLE_ID_EQUALS_PARAM;
 
         db.delete(DatabaseConstants.TABLE_DEFS_TABLE_NAME, whereClause, whereArgs);
+      }
+
+      // Delete the form definition(s) for the tableId
+      {
+        String whereClause = K_FORM_DEFS_TABLE_ID_EQUALS_PARAM;
+
+        db.delete(DatabaseConstants.FORMS_TABLE_NAME, whereClause, whereArgs);
       }
 
       // Delete the column definitions for this tableId

--- a/services_app/src/main/java/org/opendatakit/services/forms/provider/FormsProvider.java
+++ b/services_app/src/main/java/org/opendatakit/services/forms/provider/FormsProvider.java
@@ -549,10 +549,10 @@ public class FormsProvider extends ContentProvider {
             fs.tableId + "." + fs.formId + "." + System.currentTimeMillis());
 
         try {
-          ODKFileUtils.moveDirectory(srcDir, destDir);
           if (db.delete(DatabaseConstants.FORMS_TABLE_NAME, FormsColumns._ID + "=?", new String[]{ id }) > 0) {
             fs.success = true;
           }
+          ODKFileUtils.moveDirectory(srcDir, destDir);
         } catch (IOException e) {
           logger.e(t, "Unable to move directory prior to deleting it: " + e);
           logger.printStackTrace(e);


### PR DESCRIPTION
This fixes https://github.com/opendatakit/opendatakit/issues/1328 by deleting the corresponding form defintions from the _formDefs table in the deleteTableAndAllData function.  Also, deletes these entries using the FormsProvider even if there was an error while trying to delete the forms directories.    