### PR TITLE
metadata cache propagation to JS layer.

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/database/utlities/ODKDatabaseImplUtils.java
+++ b/services_app/src/main/java/org/opendatakit/services/database/utlities/ODKDatabaseImplUtils.java
@@ -892,9 +892,6 @@ public final class ODKDatabaseImplUtils {
 
     table.setEffectiveAccessCreateRow(canCreateRow);
 
-    if (tableId != null) {
-      table.setMetaDataRev(getTableDefinitionRevId(db, tableId));
-    }
     return table;
   }
 


### PR DESCRIPTION
Remove metaDataRev field from BaseTable and UserTable. Not used. Revision tracking is done separately in the APIs to retrieve the KVS entries.  Dependent upon #https://github.com/opendatakit/androidlibrary/pull/36