### PR TITLE
Improve downloading of App and Table level files for Sync

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
@@ -65,6 +65,11 @@ class ProcessManifestContentAndFileChanges {
    */
   private static final long MAX_BATCH_SIZE = 10485760;
 
+  /**
+   * Default maximum number of times to re-download a file before giving up
+   */
+  private static final int DEFAULT_DL_MAX_RETRY_COUNT = 3;
+
 
   private final SyncExecutionContext sc;
   private final WebLoggerIf log;
@@ -633,12 +638,13 @@ class ProcessManifestContentAndFileChanges {
       ODKFileUtils.createFolder(folderPath);
       if (!localFile.exists()) {
         // the file doesn't exist on the system
-        // filesToDL.add(localFile);
         boolean success = false;
         try {
-          sc.getSynchronizer().downloadFile(localFile, uri);
-          updateFileSyncETag(uri, tableId, localFile.lastModified(), entry.md5hash);
-          success = true;
+          success = downloadFile(localFile, uri, entry.md5hash);
+
+          if (success) {
+            updateFileSyncETag(uri, tableId, localFile.lastModified(), entry.md5hash);
+          }
         } finally {
           if ( !success ) {
             log.e(LOGTAG, "trouble downloading file " + entry.filename + " + for first time");
@@ -666,9 +672,11 @@ class ProcessManifestContentAndFileChanges {
           // it's not up to date, we need to download it.
           boolean success = false;
           try {
-            sc.getSynchronizer().downloadFile(localFile, uri);
-            updateFileSyncETag(uri, tableId, localFile.lastModified(), entry.md5hash);
-            success = true;
+            success = downloadFile(localFile, uri, entry.md5hash);
+
+            if (success) {
+              updateFileSyncETag(uri, tableId, localFile.lastModified(), entry.md5hash);
+            }
           } finally {
             if ( !success ) {
               log.e(LOGTAG, "trouble downloading new version of file " + entry.filename);
@@ -958,6 +966,50 @@ class ProcessManifestContentAndFileChanges {
       log.i(LOGTAG, "syncRowLevelFileAttachments PENDING file attachments for " + instanceId);
       return false;
     }
+  }
+
+  /**
+   * Wrapper around downloadFile with the default maximum number
+   * of retries set to DEFAULT_DL_MAX_RETRY_COUNT
+   *
+   * @param destFile
+   * @param downloadUri
+   * @param expectedMd5Hash
+   * @return true if the download was successful, false if otherwise
+   * @throws IOException
+   */
+  private boolean downloadFile(File destFile, URI downloadUri, String expectedMd5Hash)
+      throws IOException {
+    return downloadFile(destFile, downloadUri, expectedMd5Hash, DEFAULT_DL_MAX_RETRY_COUNT);
+  }
+
+  /**
+   * Wrapper around Synchronizer.downloadFile that invokes that method first
+   * then checks the downloaded file's integrity.
+   *
+   * Negative maxRetry is considered as 0.
+   *
+   * @param destFile
+   * @param downloadUri
+   * @param expectedMd5Hash
+   * @param maxRetry
+   * @return true if the download was successful, false if otherwise
+   * @throws IOException
+   */
+  private boolean downloadFile(File destFile, URI downloadUri, String expectedMd5Hash, int maxRetry)
+      throws IOException {
+    if (maxRetry < 0) {
+      maxRetry = 0;
+    }
+
+    boolean hashMatch;
+
+    do {
+      sc.getSynchronizer().downloadFile(destFile, downloadUri);
+      hashMatch = ODKFileUtils.getMd5Hash(sc.getAppName(), destFile).equals(expectedMd5Hash);
+    } while (maxRetry-- > 0 && !hashMatch);
+
+    return hashMatch;
   }
 
   /**********************************************************************************

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
@@ -667,7 +667,7 @@ class ProcessManifestContentAndFileChanges {
           boolean success = false;
           try {
             sc.getSynchronizer().downloadFile(localFile, uri);
-            updateFileSyncETag(uri, tableId, localFile.lastModified(), md5hash);
+            updateFileSyncETag(uri, tableId, localFile.lastModified(), entry.md5hash);
             success = true;
           } finally {
             if ( !success ) {


### PR DESCRIPTION
Addresses 2 issues:

1. During Sync of app level and table level files, md5 hashes of app / table level files are cached in the local db for future Syncs. This commit fixes a problem where if a local file is found to have a cached md5 that doesn't match the md5 in the file manifest, the locally cached out-of-date md5 is re-inserted to the db instead of the correct hash. 

2. This PR also adds file integrity check for app and table level files downloaded from the server. 