### PR TITLE
Replace support-v13 ActivityCompat with support-v4 ActivityCompat

### DIFF
--- a/services_app/build.gradle
+++ b/services_app/build.gradle
@@ -117,6 +117,7 @@ dependencies {
     implementation fileTree(include: '*.jar', dir: 'libs')
     implementation 'com.android.support:support-annotations:27.1.0'
     implementation 'com.android.support:support-v13:27.1.0'
+    implementation 'com.android.support:support-v4:27.1.0'
     implementation 'com.google.firebase:firebase-core:11.8.0'
     implementation ('com.crashlytics.sdk.android:crashlytics:2.9.1@aar') {
         transitive = true;

--- a/services_app/src/main/java/org/opendatakit/services/MainActivity.java
+++ b/services_app/src/main/java/org/opendatakit/services/MainActivity.java
@@ -24,7 +24,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v13.app.ActivityCompat;
+import android.support.v4.app.ActivityCompat;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;


### PR DESCRIPTION
ActivityCompat is deprecated in support library 27.1.0 and replaced by ActivityCompat in support-v4.
This pull request replaces usage of v13 ActivityCompat with v4 ActivityCompat.