### PR TITLE
Fixed bug asking user to configure settings even if they have manually done so

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/preferences/activities/AppPropertiesActivity.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/activities/AppPropertiesActivity.java
@@ -25,7 +25,6 @@ import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
-
 import org.opendatakit.activities.IAppAwareActivity;
 import org.opendatakit.consts.IntentConsts;
 import org.opendatakit.properties.CommonToolProperties;
@@ -43,6 +42,8 @@ import org.opendatakit.services.preferences.fragments.SettingsMenuFragment;
 import org.opendatakit.services.preferences.fragments.TablesSettingsFragment;
 import org.opendatakit.services.sync.actions.activities.VerifyServerSettingsActivity;
 import org.opendatakit.utilities.ODKFileUtils;
+
+import java.util.Collections;
 
 /**
  * App-level settings activity.  Used across all tools.
@@ -129,8 +130,17 @@ public class AppPropertiesActivity extends AppCompatActivity implements
   @Override
   public boolean onPreferenceStartFragment(PreferenceFragmentCompat caller, Preference pref) {
     Fragment prefFragment;
-
     if (pref.getFragment().equals(ServerSettingsFragment.class.getName())) {
+      // When the user first presses for the Server Settings button,
+      // the firstLaunch boolean should be set to false so that the config screen
+      // will no longer prompt the user to set their configuration (since they already have)
+      boolean isFirstLaunch = mProps.getBooleanProperty(CommonToolProperties.KEY_FIRST_LAUNCH);
+      if (isFirstLaunch) {
+        // the user has not entered the sync screen before entering the configure screen.
+        // set FirstLaunch to false
+        mProps.setProperties(Collections.singletonMap(CommonToolProperties
+                .KEY_FIRST_LAUNCH, "false"));
+      }
       prefFragment = new ServerSettingsFragment();
     } else if (pref.getFragment().equals(DeviceSettingsFragment.class.getName())) {
       prefFragment = new DeviceSettingsFragment();

--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
@@ -54,7 +54,6 @@ import org.opendatakit.services.utilities.TableHealthValidator;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/ServerSettingsFragment.java
@@ -54,6 +54,7 @@ import org.opendatakit.services.utilities.TableHealthValidator;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/services_app/src/main/java/org/opendatakit/services/sync/actions/activities/SyncActivity.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/actions/activities/SyncActivity.java
@@ -22,7 +22,6 @@ import android.support.v4.app.FragmentTransaction;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.preference.PreferenceActivity;
-
 import org.opendatakit.logging.WebLogger;
 import org.opendatakit.properties.CommonToolProperties;
 import org.opendatakit.services.MainActivity;


### PR DESCRIPTION
closes

addresses 

What is included in this PR?
Fixed a bug where the user is prompted to configure their server settings on the first entrance to the sync screen even if they've already manually configured settings.

What new issues will need to be opened because of this PR?
None

What is left to be done in the addressed issue?
None

What problems did you encounter?
None