### PR TITLE
Fix Android 9 syncing error

### DIFF
--- a/services_app/src/main/AndroidManifest.xml
+++ b/services_app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <permission-group android:description="@string/services_permissions_description"
                       android:icon="@drawable/odk_services"


### PR DESCRIPTION
Could not sync on Android 9 due to lack of FOREGROUND_SERVICE permission.
More here: https://developer.android.com/about/versions/pie/android-9.0-migration#tya